### PR TITLE
Add --version flag to terrifi CLI

### DIFF
--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -24,7 +24,7 @@ builds:
       - amd64
       - arm64
     ldflags:
-      - -s -w
+      - -s -w -X main.version={{.Version}}
 
 archives:
   - id: provider

--- a/cmd/terrifi/main.go
+++ b/cmd/terrifi/main.go
@@ -7,10 +7,18 @@ import (
 	"github.com/spf13/cobra"
 )
 
+// version is set at build time via ldflags:
+//
+//	go build -ldflags "-X main.version=v1.0.0"
+//
+// GoReleaser sets this automatically.
+var version = "dev"
+
 func main() {
 	rootCmd := &cobra.Command{
-		Use:   "terrifi",
-		Short: "Terrifi CLI — tools for managing UniFi infrastructure with Terraform",
+		Use:     "terrifi",
+		Short:   "Terrifi CLI — tools for managing UniFi infrastructure with Terraform",
+		Version: version,
 	}
 
 	rootCmd.AddCommand(generateImportsCmd())


### PR DESCRIPTION
## Summary
- Adds `--version` flag to the terrifi CLI via a build-time `ldflags` variable
- GoReleaser injects the release tag automatically; local builds default to `"dev"`

## Test plan
- [x] `go build && ./terrifi --version` prints `terrifi version dev`
- [ ] Verify GoReleaser release includes version in CLI binary

🤖 Generated with [Claude Code](https://claude.com/claude-code)