### PR TITLE
Add check-connection command to terrifi CLI

### DIFF
--- a/cmd/terrifi/check_connection.go
+++ b/cmd/terrifi/check_connection.go
@@ -1,0 +1,51 @@
+package main
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/alexklibisz/terrifi/internal/provider"
+	"github.com/spf13/cobra"
+)
+
+func checkConnectionCmd() *cobra.Command {
+	return &cobra.Command{
+		Use:   "check-connection",
+		Short: "Verify that the UNIFI_* environment variables are configured correctly",
+		Args:  cobra.NoArgs,
+		RunE:  runCheckConnection,
+	}
+}
+
+func runCheckConnection(cmd *cobra.Command, args []string) error {
+	ctx := context.Background()
+
+	cfg := provider.ClientConfigFromEnv()
+	client, err := provider.NewClient(ctx, cfg)
+	if err != nil {
+		return fmt.Errorf("connection failed: %w", err)
+	}
+
+	sites, err := client.ListSites(ctx)
+	if err != nil {
+		return fmt.Errorf("connected but could not list sites: %w", err)
+	}
+
+	fmt.Printf("Connection successful (%s)\n", cfg.APIURL)
+	fmt.Printf("Auth: ")
+	if cfg.APIKey != "" {
+		fmt.Println("API key")
+	} else {
+		fmt.Printf("username (%s)\n", cfg.Username)
+	}
+	fmt.Printf("Sites: ")
+	for i, s := range sites {
+		if i > 0 {
+			fmt.Print(", ")
+		}
+		fmt.Print(s.Name)
+	}
+	fmt.Println()
+
+	return nil
+}

--- a/cmd/terrifi/main.go
+++ b/cmd/terrifi/main.go
@@ -14,6 +14,7 @@ func main() {
 	}
 
 	rootCmd.AddCommand(generateImportsCmd())
+	rootCmd.AddCommand(checkConnectionCmd())
 
 	if err := rootCmd.Execute(); err != nil {
 		fmt.Fprintln(os.Stderr, err)


### PR DESCRIPTION
## Summary
- Adds `terrifi check-connection` command that verifies UNIFI_* env vars are working
- Connects, authenticates, and lists available sites
- Reports auth method (API key vs username) and site names

## Test plan
- [x] `terrifi check-connection` succeeds against live hardware
- [x] `go vet` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)