### PR TITLE
Move CLI docs to docs/ and add import references

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,34 +10,11 @@ Full disclosure, much of this code is written by and with help from various AI c
 
 Compared to existing UniFi providers ([paultyng](https://github.com/paultyng/terraform-provider-unifi), [filipowm](https://github.com/filipowm/terraform-provider-unifi), [ubiquiti-community](https://github.com/ubiquiti-community/terraform-provider-unifi)), Terrifi is a nearly-from-scratch implementation with a particular focus on extensive testing, including hardware-in-the-loop testing.
 
-## CLI
-
-Terrifi includes a CLI tool for generating Terraform import blocks from a live UniFi controller.
-
-### Install
-
-```sh
-go install github.com/alexklibisz/terrifi/cmd/terrifi@latest
-```
-
-### Usage
-
-Set the same `UNIFI_*` environment variables used by the provider, then run:
-
-```sh
-terrifi generate-imports terrifi_client_device
-terrifi generate-imports terrifi_dns_record
-terrifi generate-imports terrifi_firewall_zone
-terrifi generate-imports terrifi_firewall_policy
-terrifi generate-imports terrifi_network
-terrifi generate-imports terrifi_wlan
-```
-
-This outputs Terraform `import {}` and `resource {}` blocks to stdout, which you can redirect to a `.tf` file.
-
 ## Docs
 
-- Usage docs: [docs/index.md](./docs/index.md)
+- [Provider](./docs/index.md)
+- [CLI](./docs/cli.md)
+- Resources: [client_device](./docs/resources/client_device.md), [dns_record](./docs/resources/dns_record.md), [firewall_zone](./docs/resources/firewall_zone.md), [firewall_policy](./docs/resources/firewall_policy.md), [network](./docs/resources/network.md), [wlan](./docs/resources/wlan.md)
 
 ## TODO
 

--- a/docs/cli.md
+++ b/docs/cli.md
@@ -1,0 +1,77 @@
+---
+page_title: "Terrifi CLI"
+subcategory: ""
+description: |-
+  CLI tool for generating Terraform import blocks from a live UniFi controller.
+---
+
+# Terrifi CLI
+
+The Terrifi CLI connects to a live UniFi controller and generates Terraform `import {}` and `resource {}` blocks, making it easy to bring existing infrastructure under Terraform management.
+
+## Install
+
+```sh
+go install github.com/alexklibisz/terrifi/cmd/terrifi@latest
+```
+
+## Configuration
+
+The CLI uses the same `UNIFI_*` environment variables as the [Terrifi provider](index.md):
+
+- `UNIFI_API` — Controller URL, including the port.
+- `UNIFI_API_KEY` OR `UNIFI_USERNAME` and `UNIFI_PASSWORD` — Authentication credentials.
+- `UNIFI_INSECURE` — Set to `true` for self-signed TLS certificates.
+- `UNIFI_SITE` — Site name (defaults to `default`).
+
+## Commands
+
+### check-connection
+
+Verify that your environment variables are configured correctly:
+
+```sh
+terrifi check-connection
+```
+
+### generate-imports
+
+Generate Terraform import blocks for a resource type:
+
+```sh
+terrifi generate-imports <resource_type>
+```
+
+Supported resource types:
+
+| Resource Type | Description | Docs |
+|---|---|---|
+| `terrifi_client_device` | Client devices (aliases, fixed IPs, etc.) | [client_device](resources/client_device.md) |
+| `terrifi_dns_record` | DNS records | [dns_record](resources/dns_record.md) |
+| `terrifi_firewall_zone` | Firewall zones | [firewall_zone](resources/firewall_zone.md) |
+| `terrifi_firewall_policy` | Firewall policies | [firewall_policy](resources/firewall_policy.md) |
+| `terrifi_network` | Networks | [network](resources/network.md) |
+| `terrifi_wlan` | Wireless networks | [wlan](resources/wlan.md) |
+
+### Example
+
+```sh
+terrifi generate-imports terrifi_dns_record > imports.tf
+```
+
+This produces output like:
+
+```terraform
+import {
+  id = "abc123"
+  to = terrifi_dns_record.web_example_com
+}
+
+resource "terrifi_dns_record" "web_example_com" {
+  name        = "web.example.com"
+  value       = "192.168.1.100"
+  record_type = "A"
+}
+```
+
+You can then run `terraform plan` to verify and `terraform apply` to complete the import.

--- a/docs/resources/client_device.md
+++ b/docs/resources/client_device.md
@@ -99,3 +99,9 @@ To import from a non-default site, use the `site:id` format:
 ```shell
 terraform import terrifi_client_device.printer <site>:<id>
 ```
+
+You can also use the [Terrifi CLI](../cli.md) to generate import blocks for all client devices automatically:
+
+```shell
+terrifi generate-imports terrifi_client_device
+```

--- a/docs/resources/dns_record.md
+++ b/docs/resources/dns_record.md
@@ -70,3 +70,9 @@ To import a record from a non-default site, use the `site:id` format:
 ```shell
 terraform import terrifi_dns_record.web <site>:<id>
 ```
+
+You can also use the [Terrifi CLI](../cli.md) to generate import blocks for all DNS records automatically:
+
+```shell
+terrifi generate-imports terrifi_dns_record
+```

--- a/docs/resources/firewall_policy.md
+++ b/docs/resources/firewall_policy.md
@@ -164,3 +164,9 @@ To import from a non-default site, use the `site:id` format:
 ```shell
 terraform import terrifi_firewall_policy.example <site>:<id>
 ```
+
+You can also use the [Terrifi CLI](../cli.md) to generate import blocks for all firewall policies automatically:
+
+```shell
+terrifi generate-imports terrifi_firewall_policy
+```

--- a/docs/resources/firewall_zone.md
+++ b/docs/resources/firewall_zone.md
@@ -66,3 +66,9 @@ To import a firewall zone from a non-default site, use the `site:id` format:
 ```shell
 terraform import terrifi_firewall_zone.iot <site>:<id>
 ```
+
+You can also use the [Terrifi CLI](../cli.md) to generate import blocks for all firewall zones automatically:
+
+```shell
+terrifi generate-imports terrifi_firewall_zone
+```

--- a/docs/resources/network.md
+++ b/docs/resources/network.md
@@ -66,3 +66,9 @@ To import a network from a non-default site, use the `site:id` format:
 ```shell
 terraform import terrifi_network.iot <site>:<id>
 ```
+
+You can also use the [Terrifi CLI](../cli.md) to generate import blocks for all networks automatically:
+
+```shell
+terrifi generate-imports terrifi_network
+```

--- a/docs/resources/wlan.md
+++ b/docs/resources/wlan.md
@@ -102,4 +102,10 @@ To import a WLAN from a non-default site, use the `site:id` format:
 terraform import terrifi_wlan.home <site>:<id>
 ```
 
+You can also use the [Terrifi CLI](../cli.md) to generate import blocks for all WLANs automatically:
+
+```shell
+terrifi generate-imports terrifi_wlan
+```
+
 ~> **Note:** The `passphrase` attribute cannot be imported because the UniFi API does not return it. After import, set the passphrase in your configuration and run `terraform apply` to update it.


### PR DESCRIPTION
## Summary
- Creates `docs/cli.md` with install, configuration, and usage documentation for the terrifi CLI
- Updates README to link to the docs folder instead of inlining CLI content
- Adds CLI `generate-imports` references to the Import section of all 6 resource docs

## Test plan
- [ ] Verify all markdown links resolve correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)