### PR TITLE
Add terrifi_client_group to CLI generate-imports

### DIFF
--- a/cmd/terrifi/generate_imports.go
+++ b/cmd/terrifi/generate_imports.go
@@ -12,6 +12,7 @@ import (
 
 var validResourceTypes = []string{
 	"terrifi_client_device",
+	"terrifi_client_group",
 	"terrifi_dns_record",
 	"terrifi_firewall_zone",
 	"terrifi_firewall_policy",
@@ -51,6 +52,13 @@ func runGenerateImports(cmd *cobra.Command, args []string) error {
 			return fmt.Errorf("listing client devices: %w", err)
 		}
 		blocks = generate.ClientDeviceBlocks(clients)
+
+	case "terrifi_client_group":
+		groups, err := client.ListClientGroup(ctx, site)
+		if err != nil {
+			return fmt.Errorf("listing client groups: %w", err)
+		}
+		blocks = generate.ClientGroupBlocks(groups)
 
 	case "terrifi_dns_record":
 		records, err := client.ListDNSRecord(ctx, site)

--- a/cmd/terrifi/generate_imports_test.go
+++ b/cmd/terrifi/generate_imports_test.go
@@ -149,6 +149,36 @@ resource "terrifi_client_device" "test" {
 	})
 }
 
+func TestAccGenerateImports_ClientGroup(t *testing.T) {
+	requireHardware(t)
+	name := fmt.Sprintf("terrifi-test-group-%s", randomSuffix())
+
+	resource.Test(t, resource.TestCase{
+		ProtoV6ProviderFactories: testAccProtoV6ProviderFactories,
+		Steps: []resource.TestStep{
+			{
+				Config: fmt.Sprintf(`
+resource "terrifi_client_group" "test" {
+  name = %q
+}
+`, name),
+				Check: func(s *terraform.State) error {
+					id, err := resourceID(s, "terrifi_client_group.test")
+					if err != nil {
+						return err
+					}
+					tfName := strings.ReplaceAll(name, "-", "_")
+					return assertCLIOutput(t, "terrifi_client_group",
+						fmt.Sprintf(`id = "%s"`, id),
+						fmt.Sprintf(`terrifi_client_group.%s`, tfName),
+						fmt.Sprintf(`name = "%s"`, name),
+					)
+				},
+			},
+		},
+	})
+}
+
 func TestAccGenerateImports_DNSRecord(t *testing.T) {
 	requireHardware(t)
 	suffix := randomSuffix()

--- a/docs/cli.md
+++ b/docs/cli.md
@@ -47,6 +47,7 @@ Supported resource types:
 | Resource Type | Description | Docs |
 |---|---|---|
 | `terrifi_client_device` | Client devices (aliases, fixed IPs, etc.) | [client_device](resources/client_device.md) |
+| `terrifi_client_group` | Client groups | [client_group](resources/client_group.md) |
 | `terrifi_dns_record` | DNS records | [dns_record](resources/dns_record.md) |
 | `terrifi_firewall_zone` | Firewall zones | [firewall_zone](resources/firewall_zone.md) |
 | `terrifi_firewall_policy` | Firewall policies | [firewall_policy](resources/firewall_policy.md) |

--- a/docs/resources/client_group.md
+++ b/docs/resources/client_group.md
@@ -66,3 +66,9 @@ To import a client group from a non-default site, use the `site:id` format:
 ```shell
 terraform import terrifi_client_group.smart_plugs <site>:<id>
 ```
+
+You can also use the [Terrifi CLI](../cli.md) to generate import blocks for all client groups automatically:
+
+```shell
+terrifi generate-imports terrifi_client_group
+```

--- a/internal/generate/client_group.go
+++ b/internal/generate/client_group.go
@@ -1,0 +1,23 @@
+package generate
+
+import (
+	"github.com/ubiquiti-community/go-unifi/unifi"
+)
+
+// ClientGroupBlocks generates import + resource blocks for client groups.
+func ClientGroupBlocks(groups []unifi.ClientGroup) []ResourceBlock {
+	blocks := make([]ResourceBlock, 0, len(groups))
+	for _, g := range groups {
+		block := ResourceBlock{
+			ResourceType: "terrifi_client_group",
+			ResourceName: ToTerraformName(g.Name),
+			ImportID:     g.ID,
+		}
+
+		block.Attributes = append(block.Attributes, Attr{Key: "name", Value: HCLString(g.Name)})
+
+		blocks = append(blocks, block)
+	}
+	DeduplicateNames(blocks)
+	return blocks
+}

--- a/internal/generate/generate_test.go
+++ b/internal/generate/generate_test.go
@@ -557,6 +557,37 @@ func TestWLANBlocks(t *testing.T) {
 }
 
 // ---------------------------------------------------------------------------
+// ClientGroupBlocks
+// ---------------------------------------------------------------------------
+
+func TestClientGroupBlocks(t *testing.T) {
+	groups := []unifi.ClientGroup{
+		{
+			ID:   "grp1",
+			Name: "WiFi Smart Plugs",
+		},
+		{
+			ID:   "grp2",
+			Name: "IoT Devices",
+		},
+	}
+
+	blocks := ClientGroupBlocks(groups)
+	require.Len(t, blocks, 2)
+
+	b := blocks[0]
+	assert.Equal(t, "terrifi_client_group", b.ResourceType)
+	assert.Equal(t, "wifi_smart_plugs", b.ResourceName)
+	assert.Equal(t, "grp1", b.ImportID)
+
+	attrs := attrMapFromBlock(b)
+	assert.Equal(t, `"WiFi Smart Plugs"`, attrs["name"])
+
+	b2 := blocks[1]
+	assert.Equal(t, "iot_devices", b2.ResourceName)
+}
+
+// ---------------------------------------------------------------------------
 // Helpers
 // ---------------------------------------------------------------------------
 


### PR DESCRIPTION
## Summary
- Adds `terrifi_client_group` support to `terrifi generate-imports`
- New generator in `internal/generate/client_group.go`
- Unit test and hardware acceptance test
- Updated CLI docs and client_group resource docs with CLI reference

## Test plan
- [x] `task test:cli` — unit tests pass (17/17)
- [x] `task test:cli:acc:hardware` — acceptance tests pass (7/7)

🤖 Generated with [Claude Code](https://claude.com/claude-code)