### PR TITLE
Fix GoReleaser v2 compatibility and tag selection

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -41,3 +41,4 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           GPG_FINGERPRINT: ${{ steps.import_gpg.outputs.fingerprint }}
+          GORELEASER_CURRENT_TAG: ${{ github.event.inputs.tag }}

--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -1,3 +1,5 @@
+version: 2
+
 builds:
   - id: provider
     binary: terraform-provider-terrifi
@@ -28,15 +30,17 @@ builds:
 
 archives:
   - id: provider
-    builds:
+    ids:
       - provider
-    format: zip
+    formats:
+      - zip
     name_template: "{{ .ProjectName }}_{{ .Version }}_{{ .Os }}_{{ .Arch }}"
 
   - id: cli
-    builds:
+    ids:
       - cli
-    format: zip
+    formats:
+      - zip
     name_template: "terrifi-cli_{{ .Version }}_{{ .Os }}_{{ .Arch }}"
 
 checksum:


### PR DESCRIPTION
## Summary

- Add `version: 2` to `.goreleaser.yml` (required by GoReleaser v2)
- Rename deprecated `builds`/`format` to `ids`/`formats` in archives
- Set `GORELEASER_CURRENT_TAG` in the release workflow so GoReleaser uses the intended tag instead of picking up a stale prerelease tag via `git describe`

Fixes the v0.1.0 release failure where GoReleaser resolved to `v0.1.0-RC4` and tried to upload to the existing RC4 release.

## Test plan

- [ ] Merge, delete the failed v0.1.0 release/tag, re-trigger the release workflow with `v0.1.0`
- [ ] Verify no deprecation warnings and correct tag in GoReleaser output

🤖 Generated with [Claude Code](https://claude.com/claude-code)