### PR TITLE
Bump mongo 4.4 to 8.2 and document AVX requirement

### DIFF
--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -7,7 +7,10 @@
 # provider_test.go starts/stops this via testcontainers-go.
 services:
   mongo:
-    image: mongo:4.4
+    # Note: MongoDB 5.0+ requires AVX CPU instructions. If running in a VM,
+    # ensure the hypervisor passes through the host CPU (e.g. cpu type "host"
+    # in Proxmox). See https://github.com/docker-library/mongo/issues/619
+    image: mongo:8.2
     environment:
       MONGO_INITDB_ROOT_USERNAME: root
       MONGO_INITDB_ROOT_PASSWORD: root
@@ -54,7 +57,7 @@ configs:
       #!/bin/bash
       # Init scripts run against the temp mongod (no auth) before it restarts
       # with --auth. Create the unifi user in admin so MONGO_AUTHSOURCE=admin works.
-      mongo admin <<EOJS
+      mongosh admin <<EOJS
       db.createUser({
         user: "unifi",
         pwd: "unifi",


### PR DESCRIPTION
## Summary

- Bump `mongo:4.4` → `mongo:8.2` — the previous pin was due to running in a Proxmox VM with an emulated CPU type (no AVX). With the hypervisor configured to pass through the host CPU (`cpu type: host`), 8.2 works fine.
- Update init script from `mongo` to `mongosh` (the legacy mongo shell was removed in MongoDB 6.0)
- Add comment to `docker-compose.yaml` documenting the AVX requirement and Proxmox workaround
- Revert the Dependabot ignore for mongo (no longer needed)

Tested locally: full `docker-compose up` with UniFi controller `version-10.1.85` starts healthy against mongo 8.2.

Closes #39

🤖 Generated with [Claude Code](https://claude.com/claude-code)