### PR TITLE
Add enabled attribute to terrifi_wlan resource

### DIFF
--- a/docs/resources/wlan.md
+++ b/docs/resources/wlan.md
@@ -66,6 +66,17 @@ resource "terrifi_wlan" "guest" {
 }
 ```
 
+### Disabled WLAN
+
+```terraform
+resource "terrifi_wlan" "maintenance" {
+  name       = "Maintenance WiFi"
+  passphrase = var.wifi_passphrase
+  network_id = terrifi_network.main.id
+  enabled    = false
+}
+```
+
 ## Schema
 
 ### Required
@@ -75,6 +86,7 @@ resource "terrifi_wlan" "guest" {
 
 ### Optional
 
+- `enabled` (Boolean) — Whether the WLAN is enabled. Defaults to `true`.
 - `passphrase` (String, Sensitive) — The WPA passphrase. Must be 8-255 characters. Required when `security` is `wpapsk`.
 - `wifi_band` (String) — The WiFi band. Must be `2g`, `5g`, or `both`. Defaults to `both`.
 - `security` (String) — The security protocol. Must be `open` or `wpapsk`. Defaults to `wpapsk`.

--- a/internal/generate/wlan.go
+++ b/internal/generate/wlan.go
@@ -26,6 +26,9 @@ func WLANBlocks(wlans []unifi.WLAN) []ResourceBlock {
 			Comment: "TODO: find and reference corresponding terrifi_network resource",
 		})
 
+		if !w.Enabled {
+			block.Attributes = append(block.Attributes, Attr{Key: "enabled", Value: HCLBool(false)})
+		}
 		if w.WLANBand != "" && w.WLANBand != "both" {
 			block.Attributes = append(block.Attributes, Attr{Key: "wifi_band", Value: HCLString(w.WLANBand)})
 		}


### PR DESCRIPTION
## Summary
- Adds an `enabled` boolean attribute to the `terrifi_wlan` resource, defaulting to `true` for backward compatibility
- Replaces the hardcoded `Enabled: true` in `modelToAPI()` with the user-configurable field
- Updates model, schema, CRUD helpers (`modelToAPI`, `apiToModel`, `applyPlanToState`), import generation, docs, and tests

Closes #32

## Test plan
- [x] Unit tests pass: `TestWLANModelToAPI` (including new `disabled WLAN` case), `TestWLANAPIToModel` (including new `disabled WLAN from API` case), `TestWLANApplyPlanToState`
- [x] Full unit test suite passes with no regressions
- [ ] Acceptance test `TestAccWLAN_basic` verifies `enabled` defaults to `true`
- [ ] Acceptance test `TestAccWLAN_disabled` creates a WLAN with `enabled = false`
- [ ] Acceptance test `TestAccWLAN_updateEnabled` toggles `enabled` true → false → true

🤖 Generated with [Claude Code](https://claude.com/claude-code)