### PR TITLE
Fix UOS Server download URL and update unifi-api skill

### DIFF
--- a/.claude/skills/unifi-api.md
+++ b/.claude/skills/unifi-api.md
@@ -54,12 +54,11 @@ Default site is `default`.
 To view recent logs from the UniFi controller (useful for diagnosing 500 errors, Java stack traces, etc.):
 
 ```bash
-hardware-testing/show_logs.sh 90s    # logs from last 90 seconds
-hardware-testing/show_logs.sh 5m     # logs from last 5 minutes
-hardware-testing/show_logs.sh        # default: last 60 seconds
+ssh terrifi-unifi-os-server './logs.sh'           # tail server.log (default)
+ssh terrifi-unifi-os-server './logs.sh mongod'     # tail mongod.log
 ```
 
-This SSHs to the hardware controller and runs `docker compose logs`. Use this when API calls return 500 errors to see the server-side Java stack trace.
+This SSHs to the UOS Server host and tails logs from inside the podman container. Use this when API calls return 500 errors to see the server-side Java stack trace. The command streams continuously — kill it with Ctrl+C once you've captured what you need.
 
 ## Output Guidelines
 

--- a/hardware-testing/unifi-os-server/install.sh
+++ b/hardware-testing/unifi-os-server/install.sh
@@ -6,14 +6,18 @@
 # mode. The installer creates a podman container managed by a systemd service.
 #
 # Usage:
-#   sudo ./install.sh              # install default version (5.0.6)
-#   sudo ./install.sh 4.3.6        # install a specific version
+#   sudo ./install.sh                        # install default version
+#   sudo DOWNLOAD_URL=<url> ./install.sh     # install from an explicit URL
+#
+# Ubiquiti download URLs contain per-release UUIDs and cannot be derived from
+# the version number alone.  Get the latest URL from:
+#   https://ui.com/download/releases/unifi-os-server
 
 set -euo pipefail
 
-VERSION="${1:-5.0.6}"
-PLATFORM="x64"
-DOWNLOAD_URL="https://fw-download.ubnt.com/data/uos-server/${VERSION}/uosserver-installer-${VERSION}-${PLATFORM}.bin"
+# Default download URL for UOS Server 5.0.6 (x64).
+# Override with the DOWNLOAD_URL env var when a newer version is released.
+DOWNLOAD_URL="${DOWNLOAD_URL:-https://fw-download.ubnt.com/data/unifi-os-server/1856-linux-x64-5.0.6-33f4990f-6c68-4e72-9d9c-477496c22450.6-x64}"
 
 # ── Preflight ────────────────────────────────────────────────────────
 
@@ -39,7 +43,7 @@ trap 'rm -rf "$TMPDIR"' EXIT
 
 INSTALLER="${TMPDIR}/uosserver-installer.bin"
 
-echo "Downloading UOS Server v${VERSION} (${PLATFORM}) ..."
+echo "Downloading UOS Server installer ..."
 echo "  URL: ${DOWNLOAD_URL}"
 curl -fSL -o "$INSTALLER" "$DOWNLOAD_URL"
 chmod +x "$INSTALLER"


### PR DESCRIPTION
## Summary
- **install.sh**: Ubiquiti changed the firmware download URL format — the old `/data/uos-server/` path now returns 403. Replaced the templated URL with the correct hardcoded URL for 5.0.6 x64 and added a `DOWNLOAD_URL` env var override for future versions.
- **unifi-api skill**: Updated controller logs section to reference `logs.sh` (the old `show_logs.sh` no longer exists after the Docker Compose to UOS Server migration).

## Test plan
- [x] Verified install.sh downloads successfully with the new URL on the UOS Server host

🤖 Generated with [Claude Code](https://claude.com/claude-code)