### PR TITLE
Allow fixed_ip with network_override_id instead of network_id

### DIFF
--- a/docs/resources/client_device.md
+++ b/docs/resources/client_device.md
@@ -41,6 +41,19 @@ resource "terrifi_client_device" "server" {
 }
 ```
 
+### Fixed IP with network override
+
+When using a network override, `network_id` is not required — the override provides the network context.
+
+```terraform
+resource "terrifi_client_device" "laptop" {
+  mac                 = "22:33:44:55:66:77"
+  name                = "Work Laptop"
+  fixed_ip            = "192.168.10.20"
+  network_override_id = terrifi_network.lan.id
+}
+```
+
 ### Local DNS record
 
 Local DNS records require a fixed IP assignment (controller requirement).
@@ -75,8 +88,8 @@ resource "terrifi_client_device" "blocked" {
 
 - `name` (String) — The alias/display name for the client device.
 - `note` (String) — A free-text note for the client device.
-- `fixed_ip` (String) — A fixed IP address to assign via DHCP reservation. Requires `network_id`.
-- `network_id` (String) — The network ID for fixed IP assignment. Required when `fixed_ip` is set.
+- `fixed_ip` (String) — A fixed IP address to assign via DHCP reservation. Requires `network_id` or `network_override_id`.
+- `network_id` (String) — The network ID for fixed IP assignment. Required when `fixed_ip` is set unless `network_override_id` provides the network context.
 - `network_override_id` (String) — The network ID for VLAN/network override.
 - `local_dns_record` (String) — A local DNS hostname for this client device. Requires `fixed_ip`.
 - `client_group_id` (String) — The ID of the client group to assign this device to. Use `terrifi_client_group` to manage groups.


### PR DESCRIPTION
## Summary

Closes #42.

- Replace the strict `AlsoRequires(network_id)` validator on `fixed_ip` with a resource-level config validator that accepts either `network_id` or `network_override_id` (or both)
- Add unit test for `fixed_ip` + `network_override_id` model-to-API conversion
- Add acceptance tests for fixed IP with network override, fixed IP with both networks, and switching between network_id and network_override_id
- Update docs with a new "Fixed IP with network override" example and updated attribute descriptions

## Test plan

- [x] Unit tests pass (`task test:unit`)
- [x] Lint passes (`task lint`)
- [ ] Acceptance tests pass (`task test:acc -- -run TestAccClientDevice_fixedIPWithNetworkOverride`)
- [ ] Acceptance tests pass (`task test:acc -- -run TestAccClientDevice_fixedIPWithBothNetworks`)
- [ ] Acceptance tests pass (`task test:acc -- -run TestAccClientDevice_updateFixedIPNetworkToOverride`)
- [ ] Existing acceptance tests still pass (`task test:acc -- -run TestAccClientDevice`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)