### PR TITLE
Add workflow_dispatch trigger to CI workflows

### DIFF
--- a/.github/workflows/ci-hil.yaml
+++ b/.github/workflows/ci-hil.yaml
@@ -5,6 +5,7 @@ concurrency:
   cancel-in-progress: false
 
 on:
+  workflow_dispatch:
   pull_request:
     branches: [main]
 

--- a/.github/workflows/ci-local.yaml
+++ b/.github/workflows/ci-local.yaml
@@ -5,6 +5,7 @@ concurrency:
   cancel-in-progress: true
 
 on:
+  workflow_dispatch:
   push:
     branches: [main]
   pull_request:


### PR DESCRIPTION
## Summary
- Add `workflow_dispatch` trigger to both `ci-hil.yaml` and `ci-local.yaml` so they can be run manually on main

## Test plan
- [ ] Verify workflows appear with "Run workflow" button in GitHub Actions UI

🤖 Generated with [Claude Code](https://claude.com/claude-code)