### PR TITLE
Fix HIL test flakiness from concurrent zone PUT race and VLAN collisions

### DIFF
--- a/internal/provider/firewall_zone_resource_test.go
+++ b/internal/provider/firewall_zone_resource_test.go
@@ -227,6 +227,7 @@ resource "terrifi_firewall_zone" "test" {
 func TestAccFirewallZone_withNetworks(t *testing.T) {
 	zoneName := fmt.Sprintf("tfacc-zone-nets-%s", randomSuffix())
 	netName := fmt.Sprintf("tfacc-net-%s", randomSuffix())
+	vlan := randomVLAN()
 	resource.Test(t, resource.TestCase{
 		PreCheck:                 func() { preCheck(t); requireHardware(t) },
 		ProtoV6ProviderFactories: testAccProtoV6ProviderFactories,
@@ -236,15 +237,15 @@ func TestAccFirewallZone_withNetworks(t *testing.T) {
 resource "terrifi_network" "test" {
   name    = %q
   purpose = "corporate"
-  vlan_id = 100
-  subnet  = "192.168.100.1/24"
+  vlan_id = %d
+  subnet  = "10.%d.%d.1/24"
 }
 
 resource "terrifi_firewall_zone" "test" {
   name        = %q
   network_ids = [terrifi_network.test.id]
 }
-`, netName, zoneName),
+`, netName, vlan, vlan/256, vlan%256, zoneName),
 				Check: resource.ComposeTestCheckFunc(
 					resource.TestCheckResourceAttr("terrifi_firewall_zone.test", "name", zoneName),
 					resource.TestCheckResourceAttr("terrifi_firewall_zone.test", "network_ids.#", "1"),
@@ -288,6 +289,7 @@ resource "terrifi_firewall_zone" "test" {
 func TestAccFirewallZone_addNetworks(t *testing.T) {
 	zoneName := fmt.Sprintf("tfacc-zone-add-%s", randomSuffix())
 	netName := fmt.Sprintf("tfacc-net-add-%s", randomSuffix())
+	vlan := randomVLAN()
 	resource.Test(t, resource.TestCase{
 		PreCheck:                 func() { preCheck(t); requireHardware(t) },
 		ProtoV6ProviderFactories: testAccProtoV6ProviderFactories,
@@ -297,14 +299,14 @@ func TestAccFirewallZone_addNetworks(t *testing.T) {
 resource "terrifi_network" "test" {
   name    = %q
   purpose = "corporate"
-  vlan_id = 101
-  subnet  = "192.168.101.1/24"
+  vlan_id = %d
+  subnet  = "10.%d.%d.1/24"
 }
 
 resource "terrifi_firewall_zone" "test" {
   name = %q
 }
-`, netName, zoneName),
+`, netName, vlan, vlan/256, vlan%256, zoneName),
 				Check: resource.ComposeTestCheckFunc(
 					resource.TestCheckResourceAttr("terrifi_firewall_zone.test", "name", zoneName),
 				),
@@ -314,15 +316,15 @@ resource "terrifi_firewall_zone" "test" {
 resource "terrifi_network" "test" {
   name    = %q
   purpose = "corporate"
-  vlan_id = 101
-  subnet  = "192.168.101.1/24"
+  vlan_id = %d
+  subnet  = "10.%d.%d.1/24"
 }
 
 resource "terrifi_firewall_zone" "test" {
   name        = %q
   network_ids = [terrifi_network.test.id]
 }
-`, netName, zoneName),
+`, netName, vlan, vlan/256, vlan%256, zoneName),
 				Check: resource.ComposeTestCheckFunc(
 					resource.TestCheckResourceAttr("terrifi_firewall_zone.test", "network_ids.#", "1"),
 				),
@@ -334,6 +336,7 @@ resource "terrifi_firewall_zone" "test" {
 func TestAccFirewallZone_removeNetworks(t *testing.T) {
 	zoneName := fmt.Sprintf("tfacc-zone-rm-%s", randomSuffix())
 	netName := fmt.Sprintf("tfacc-net-rm-%s", randomSuffix())
+	vlan := randomVLAN()
 	resource.Test(t, resource.TestCase{
 		PreCheck:                 func() { preCheck(t); requireHardware(t) },
 		ProtoV6ProviderFactories: testAccProtoV6ProviderFactories,
@@ -343,15 +346,15 @@ func TestAccFirewallZone_removeNetworks(t *testing.T) {
 resource "terrifi_network" "test" {
   name    = %q
   purpose = "corporate"
-  vlan_id = 102
-  subnet  = "192.168.102.1/24"
+  vlan_id = %d
+  subnet  = "10.%d.%d.1/24"
 }
 
 resource "terrifi_firewall_zone" "test" {
   name        = %q
   network_ids = [terrifi_network.test.id]
 }
-`, netName, zoneName),
+`, netName, vlan, vlan/256, vlan%256, zoneName),
 				Check: resource.ComposeTestCheckFunc(
 					resource.TestCheckResourceAttr("terrifi_firewall_zone.test", "network_ids.#", "1"),
 				),
@@ -361,15 +364,15 @@ resource "terrifi_firewall_zone" "test" {
 resource "terrifi_network" "test" {
   name    = %q
   purpose = "corporate"
-  vlan_id = 102
-  subnet  = "192.168.102.1/24"
+  vlan_id = %d
+  subnet  = "10.%d.%d.1/24"
 }
 
 resource "terrifi_firewall_zone" "test" {
   name        = %q
   network_ids = []
 }
-`, netName, zoneName),
+`, netName, vlan, vlan/256, vlan%256, zoneName),
 				Check: resource.ComposeTestCheckFunc(
 					resource.TestCheckResourceAttr("terrifi_firewall_zone.test", "network_ids.#", "0"),
 				),
@@ -382,6 +385,8 @@ func TestAccFirewallZone_replaceNetworks(t *testing.T) {
 	zoneName := fmt.Sprintf("tfacc-zone-repl-%s", randomSuffix())
 	net1Name := fmt.Sprintf("tfacc-net-r1-%s", randomSuffix())
 	net2Name := fmt.Sprintf("tfacc-net-r2-%s", randomSuffix())
+	vlan1 := randomVLAN()
+	vlan2 := randomVLAN()
 	resource.Test(t, resource.TestCase{
 		PreCheck:                 func() { preCheck(t); requireHardware(t) },
 		ProtoV6ProviderFactories: testAccProtoV6ProviderFactories,
@@ -391,22 +396,22 @@ func TestAccFirewallZone_replaceNetworks(t *testing.T) {
 resource "terrifi_network" "net1" {
   name    = %q
   purpose = "corporate"
-  vlan_id = 103
-  subnet  = "192.168.103.1/24"
+  vlan_id = %d
+  subnet  = "10.%d.%d.1/24"
 }
 
 resource "terrifi_network" "net2" {
   name    = %q
   purpose = "corporate"
-  vlan_id = 104
-  subnet  = "192.168.104.1/24"
+  vlan_id = %d
+  subnet  = "10.%d.%d.1/24"
 }
 
 resource "terrifi_firewall_zone" "test" {
   name        = %q
   network_ids = [terrifi_network.net1.id]
 }
-`, net1Name, net2Name, zoneName),
+`, net1Name, vlan1, vlan1/256, vlan1%256, net2Name, vlan2, vlan2/256, vlan2%256, zoneName),
 				Check: resource.ComposeTestCheckFunc(
 					resource.TestCheckResourceAttr("terrifi_firewall_zone.test", "network_ids.#", "1"),
 				),
@@ -416,22 +421,22 @@ resource "terrifi_firewall_zone" "test" {
 resource "terrifi_network" "net1" {
   name    = %q
   purpose = "corporate"
-  vlan_id = 103
-  subnet  = "192.168.103.1/24"
+  vlan_id = %d
+  subnet  = "10.%d.%d.1/24"
 }
 
 resource "terrifi_network" "net2" {
   name    = %q
   purpose = "corporate"
-  vlan_id = 104
-  subnet  = "192.168.104.1/24"
+  vlan_id = %d
+  subnet  = "10.%d.%d.1/24"
 }
 
 resource "terrifi_firewall_zone" "test" {
   name        = %q
   network_ids = [terrifi_network.net2.id]
 }
-`, net1Name, net2Name, zoneName),
+`, net1Name, vlan1, vlan1/256, vlan1%256, net2Name, vlan2, vlan2/256, vlan2%256, zoneName),
 				Check: resource.ComposeTestCheckFunc(
 					resource.TestCheckResourceAttr("terrifi_firewall_zone.test", "network_ids.#", "1"),
 				),
@@ -444,6 +449,7 @@ func TestAccFirewallZone_updateNameAndNetworks(t *testing.T) {
 	name1 := fmt.Sprintf("tfacc-zone-both1-%s", randomSuffix())
 	name2 := fmt.Sprintf("tfacc-zone-both2-%s", randomSuffix())
 	netName := fmt.Sprintf("tfacc-net-both-%s", randomSuffix())
+	vlan := randomVLAN()
 	resource.Test(t, resource.TestCase{
 		PreCheck:                 func() { preCheck(t); requireHardware(t) },
 		ProtoV6ProviderFactories: testAccProtoV6ProviderFactories,
@@ -453,14 +459,14 @@ func TestAccFirewallZone_updateNameAndNetworks(t *testing.T) {
 resource "terrifi_network" "test" {
   name    = %q
   purpose = "corporate"
-  vlan_id = 105
-  subnet  = "192.168.105.1/24"
+  vlan_id = %d
+  subnet  = "10.%d.%d.1/24"
 }
 
 resource "terrifi_firewall_zone" "test" {
   name = %q
 }
-`, netName, name1),
+`, netName, vlan, vlan/256, vlan%256, name1),
 				Check: resource.ComposeTestCheckFunc(
 					resource.TestCheckResourceAttr("terrifi_firewall_zone.test", "name", name1),
 				),
@@ -470,15 +476,15 @@ resource "terrifi_firewall_zone" "test" {
 resource "terrifi_network" "test" {
   name    = %q
   purpose = "corporate"
-  vlan_id = 105
-  subnet  = "192.168.105.1/24"
+  vlan_id = %d
+  subnet  = "10.%d.%d.1/24"
 }
 
 resource "terrifi_firewall_zone" "test" {
   name        = %q
   network_ids = [terrifi_network.test.id]
 }
-`, netName, name2),
+`, netName, vlan, vlan/256, vlan%256, name2),
 				Check: resource.ComposeTestCheckFunc(
 					resource.TestCheckResourceAttr("terrifi_firewall_zone.test", "name", name2),
 					resource.TestCheckResourceAttr("terrifi_firewall_zone.test", "network_ids.#", "1"),
@@ -594,6 +600,8 @@ func TestAccFirewallZone_multipleZonesWithDistinctNetworks(t *testing.T) {
 	zone2Name := fmt.Sprintf("tfacc-zone-dn2-%s", randomSuffix())
 	net1Name := fmt.Sprintf("tfacc-net-dn1-%s", randomSuffix())
 	net2Name := fmt.Sprintf("tfacc-net-dn2-%s", randomSuffix())
+	vlan1 := randomVLAN()
+	vlan2 := randomVLAN()
 	resource.Test(t, resource.TestCase{
 		PreCheck:                 func() { preCheck(t); requireHardware(t) },
 		ProtoV6ProviderFactories: testAccProtoV6ProviderFactories,
@@ -603,15 +611,15 @@ func TestAccFirewallZone_multipleZonesWithDistinctNetworks(t *testing.T) {
 resource "terrifi_network" "net1" {
   name    = %q
   purpose = "corporate"
-  vlan_id = 106
-  subnet  = "192.168.106.1/24"
+  vlan_id = %d
+  subnet  = "10.%d.%d.1/24"
 }
 
 resource "terrifi_network" "net2" {
   name    = %q
   purpose = "corporate"
-  vlan_id = 107
-  subnet  = "192.168.107.1/24"
+  vlan_id = %d
+  subnet  = "10.%d.%d.1/24"
 }
 
 resource "terrifi_firewall_zone" "zone1" {
@@ -623,7 +631,7 @@ resource "terrifi_firewall_zone" "zone2" {
   name        = %q
   network_ids = [terrifi_network.net2.id]
 }
-`, net1Name, net2Name, zone1Name, zone2Name),
+`, net1Name, vlan1, vlan1/256, vlan1%256, net2Name, vlan2, vlan2/256, vlan2%256, zone1Name, zone2Name),
 				Check: resource.ComposeTestCheckFunc(
 					resource.TestCheckResourceAttr("terrifi_firewall_zone.zone1", "network_ids.#", "1"),
 					resource.TestCheckResourceAttr("terrifi_firewall_zone.zone2", "network_ids.#", "1"),
@@ -636,6 +644,7 @@ resource "terrifi_firewall_zone" "zone2" {
 func TestAccFirewallZone_importWithNetworks(t *testing.T) {
 	zoneName := fmt.Sprintf("tfacc-zone-impn-%s", randomSuffix())
 	netName := fmt.Sprintf("tfacc-net-impn-%s", randomSuffix())
+	vlan := randomVLAN()
 	resource.Test(t, resource.TestCase{
 		PreCheck:                 func() { preCheck(t); requireHardware(t) },
 		ProtoV6ProviderFactories: testAccProtoV6ProviderFactories,
@@ -645,15 +654,15 @@ func TestAccFirewallZone_importWithNetworks(t *testing.T) {
 resource "terrifi_network" "test" {
   name    = %q
   purpose = "corporate"
-  vlan_id = 108
-  subnet  = "192.168.108.1/24"
+  vlan_id = %d
+  subnet  = "10.%d.%d.1/24"
 }
 
 resource "terrifi_firewall_zone" "test" {
   name        = %q
   network_ids = [terrifi_network.test.id]
 }
-`, netName, zoneName),
+`, netName, vlan, vlan/256, vlan%256, zoneName),
 				Check: resource.ComposeTestCheckFunc(
 					resource.TestCheckResourceAttr("terrifi_firewall_zone.test", "network_ids.#", "1"),
 				),
@@ -672,105 +681,69 @@ func TestAccFirewallZone_multipleNetworksInZone(t *testing.T) {
 	net1Name := fmt.Sprintf("tfacc-net-mn1-%s", randomSuffix())
 	net2Name := fmt.Sprintf("tfacc-net-mn2-%s", randomSuffix())
 	net3Name := fmt.Sprintf("tfacc-net-mn3-%s", randomSuffix())
+	vlan1 := randomVLAN()
+	vlan2 := randomVLAN()
+	vlan3 := randomVLAN()
+
+	netConfig := fmt.Sprintf(`
+resource "terrifi_network" "net1" {
+  name    = %q
+  purpose = "corporate"
+  vlan_id = %d
+  subnet  = "10.%d.%d.1/24"
+}
+
+resource "terrifi_network" "net2" {
+  name    = %q
+  purpose = "corporate"
+  vlan_id = %d
+  subnet  = "10.%d.%d.1/24"
+}
+
+resource "terrifi_network" "net3" {
+  name    = %q
+  purpose = "corporate"
+  vlan_id = %d
+  subnet  = "10.%d.%d.1/24"
+}
+`, net1Name, vlan1, vlan1/256, vlan1%256, net2Name, vlan2, vlan2/256, vlan2%256, net3Name, vlan3, vlan3/256, vlan3%256)
+
 	resource.Test(t, resource.TestCase{
 		PreCheck:                 func() { preCheck(t); requireHardware(t) },
 		ProtoV6ProviderFactories: testAccProtoV6ProviderFactories,
 		Steps: []resource.TestStep{
 			// Step 1: Create zone with 2 networks
 			{
-				Config: fmt.Sprintf(`
-resource "terrifi_network" "net1" {
-  name    = %q
-  purpose = "corporate"
-  vlan_id = 109
-  subnet  = "192.168.109.1/24"
-}
-
-resource "terrifi_network" "net2" {
-  name    = %q
-  purpose = "corporate"
-  vlan_id = 110
-  subnet  = "192.168.110.1/24"
-}
-
-resource "terrifi_network" "net3" {
-  name    = %q
-  purpose = "corporate"
-  vlan_id = 111
-  subnet  = "192.168.111.1/24"
-}
-
+				Config: netConfig + fmt.Sprintf(`
 resource "terrifi_firewall_zone" "test" {
   name        = %q
   network_ids = [terrifi_network.net1.id, terrifi_network.net2.id]
 }
-`, net1Name, net2Name, net3Name, zoneName),
+`, zoneName),
 				Check: resource.ComposeTestCheckFunc(
 					resource.TestCheckResourceAttr("terrifi_firewall_zone.test", "network_ids.#", "2"),
 				),
 			},
 			// Step 2: Add a third network
 			{
-				Config: fmt.Sprintf(`
-resource "terrifi_network" "net1" {
-  name    = %q
-  purpose = "corporate"
-  vlan_id = 109
-  subnet  = "192.168.109.1/24"
-}
-
-resource "terrifi_network" "net2" {
-  name    = %q
-  purpose = "corporate"
-  vlan_id = 110
-  subnet  = "192.168.110.1/24"
-}
-
-resource "terrifi_network" "net3" {
-  name    = %q
-  purpose = "corporate"
-  vlan_id = 111
-  subnet  = "192.168.111.1/24"
-}
-
+				Config: netConfig + fmt.Sprintf(`
 resource "terrifi_firewall_zone" "test" {
   name        = %q
   network_ids = [terrifi_network.net1.id, terrifi_network.net2.id, terrifi_network.net3.id]
 }
-`, net1Name, net2Name, net3Name, zoneName),
+`, zoneName),
 				Check: resource.ComposeTestCheckFunc(
 					resource.TestCheckResourceAttr("terrifi_firewall_zone.test", "network_ids.#", "3"),
 				),
 			},
 			// Step 3: Remove the middle network
 			{
-				Config: fmt.Sprintf(`
-resource "terrifi_network" "net1" {
-  name    = %q
-  purpose = "corporate"
-  vlan_id = 109
-  subnet  = "192.168.109.1/24"
-}
-
-resource "terrifi_network" "net2" {
-  name    = %q
-  purpose = "corporate"
-  vlan_id = 110
-  subnet  = "192.168.110.1/24"
-}
-
-resource "terrifi_network" "net3" {
-  name    = %q
-  purpose = "corporate"
-  vlan_id = 111
-  subnet  = "192.168.111.1/24"
-}
-
+				Config: netConfig + fmt.Sprintf(`
 resource "terrifi_firewall_zone" "test" {
   name        = %q
   network_ids = [terrifi_network.net1.id, terrifi_network.net3.id]
 }
-`, net1Name, net2Name, net3Name, zoneName),
+`, zoneName),
 				Check: resource.ComposeTestCheckFunc(
 					resource.TestCheckResourceAttr("terrifi_firewall_zone.test", "network_ids.#", "2"),
 				),
@@ -782,20 +755,21 @@ resource "terrifi_firewall_zone" "test" {
 func TestAccFirewallZone_idempotentReapply(t *testing.T) {
 	zoneName := fmt.Sprintf("tfacc-zone-idem-%s", randomSuffix())
 	netName := fmt.Sprintf("tfacc-net-idem-%s", randomSuffix())
+	vlan := randomVLAN()
 
 	config := fmt.Sprintf(`
 resource "terrifi_network" "test" {
   name    = %q
   purpose = "corporate"
-  vlan_id = 112
-  subnet  = "192.168.112.1/24"
+  vlan_id = %d
+  subnet  = "10.%d.%d.1/24"
 }
 
 resource "terrifi_firewall_zone" "test" {
   name        = %q
   network_ids = [terrifi_network.test.id]
 }
-`, netName, zoneName)
+`, netName, vlan, vlan/256, vlan%256, zoneName)
 
 	resource.Test(t, resource.TestCase{
 		PreCheck:                 func() { preCheck(t); requireHardware(t) },
@@ -849,20 +823,24 @@ func TestAccFirewallZone_moveNetworkBetweenZones(t *testing.T) {
 	zone1Name := fmt.Sprintf("tfacc-zone-mv1-%s", randomSuffix())
 	zone2Name := fmt.Sprintf("tfacc-zone-mv2-%s", randomSuffix())
 	netName := fmt.Sprintf("tfacc-net-mv-%s", randomSuffix())
+	vlan := randomVLAN()
+
+	netConfig := fmt.Sprintf(`
+resource "terrifi_network" "test" {
+  name    = %q
+  purpose = "corporate"
+  vlan_id = %d
+  subnet  = "10.%d.%d.1/24"
+}
+`, netName, vlan, vlan/256, vlan%256)
+
 	resource.Test(t, resource.TestCase{
 		PreCheck:                 func() { preCheck(t); requireHardware(t) },
 		ProtoV6ProviderFactories: testAccProtoV6ProviderFactories,
 		Steps: []resource.TestStep{
 			// Step 1: net belongs to zone1
 			{
-				Config: fmt.Sprintf(`
-resource "terrifi_network" "test" {
-  name    = %q
-  purpose = "corporate"
-  vlan_id = 113
-  subnet  = "192.168.113.1/24"
-}
-
+				Config: netConfig + fmt.Sprintf(`
 resource "terrifi_firewall_zone" "zone1" {
   name        = %q
   network_ids = [terrifi_network.test.id]
@@ -872,7 +850,7 @@ resource "terrifi_firewall_zone" "zone2" {
   name        = %q
   network_ids = []
 }
-`, netName, zone1Name, zone2Name),
+`, zone1Name, zone2Name),
 				Check: resource.ComposeTestCheckFunc(
 					resource.TestCheckResourceAttr("terrifi_firewall_zone.zone1", "network_ids.#", "1"),
 					resource.TestCheckResourceAttr("terrifi_firewall_zone.zone2", "network_ids.#", "0"),
@@ -880,14 +858,7 @@ resource "terrifi_firewall_zone" "zone2" {
 			},
 			// Step 2: Move net from zone1 to zone2
 			{
-				Config: fmt.Sprintf(`
-resource "terrifi_network" "test" {
-  name    = %q
-  purpose = "corporate"
-  vlan_id = 113
-  subnet  = "192.168.113.1/24"
-}
-
+				Config: netConfig + fmt.Sprintf(`
 resource "terrifi_firewall_zone" "zone1" {
   name        = %q
   network_ids = []
@@ -897,7 +868,7 @@ resource "terrifi_firewall_zone" "zone2" {
   name        = %q
   network_ids = [terrifi_network.test.id]
 }
-`, netName, zone1Name, zone2Name),
+`, zone1Name, zone2Name),
 				Check: resource.ComposeTestCheckFunc(
 					resource.TestCheckResourceAttr("terrifi_firewall_zone.zone1", "network_ids.#", "0"),
 					resource.TestCheckResourceAttr("terrifi_firewall_zone.zone2", "network_ids.#", "1"),

--- a/internal/provider/wlan_resource_test.go
+++ b/internal/provider/wlan_resource_test.go
@@ -315,6 +315,7 @@ resource "terrifi_network" "wlan_test" {
 func TestAccWLAN_basic(t *testing.T) {
 	requireHardware(t)
 	suffix := randomSuffix()
+	vlan := randomVLAN()
 	netName := fmt.Sprintf("tfacc-wlan-net-%s", suffix)
 	wlanName := fmt.Sprintf("tfacc-wlan-%s", suffix)
 
@@ -323,7 +324,7 @@ func TestAccWLAN_basic(t *testing.T) {
 		ProtoV6ProviderFactories: testAccProtoV6ProviderFactories,
 		Steps: []resource.TestStep{
 			{
-				Config: wlanTestNetwork(netName, 500) + fmt.Sprintf(`
+				Config: wlanTestNetwork(netName, vlan) + fmt.Sprintf(`
 resource "terrifi_wlan" "test" {
   name       = %q
   passphrase = "testpassword123"
@@ -351,6 +352,7 @@ resource "terrifi_wlan" "test" {
 func TestAccWLAN_disabled(t *testing.T) {
 	requireHardware(t)
 	suffix := randomSuffix()
+	vlan := randomVLAN()
 	netName := fmt.Sprintf("tfacc-wlan-net-%s", suffix)
 	wlanName := fmt.Sprintf("tfacc-wlan-%s", suffix)
 
@@ -359,7 +361,7 @@ func TestAccWLAN_disabled(t *testing.T) {
 		ProtoV6ProviderFactories: testAccProtoV6ProviderFactories,
 		Steps: []resource.TestStep{
 			{
-				Config: wlanTestNetwork(netName, 516) + fmt.Sprintf(`
+				Config: wlanTestNetwork(netName, vlan) + fmt.Sprintf(`
 resource "terrifi_wlan" "test" {
   name       = %q
   passphrase = "testpassword123"
@@ -379,6 +381,7 @@ resource "terrifi_wlan" "test" {
 func TestAccWLAN_updateEnabled(t *testing.T) {
 	requireHardware(t)
 	suffix := randomSuffix()
+	vlan := randomVLAN()
 	netName := fmt.Sprintf("tfacc-wlan-net-%s", suffix)
 	wlanName := fmt.Sprintf("tfacc-wlan-%s", suffix)
 
@@ -387,7 +390,7 @@ func TestAccWLAN_updateEnabled(t *testing.T) {
 		ProtoV6ProviderFactories: testAccProtoV6ProviderFactories,
 		Steps: []resource.TestStep{
 			{
-				Config: wlanTestNetwork(netName, 517) + fmt.Sprintf(`
+				Config: wlanTestNetwork(netName, vlan) + fmt.Sprintf(`
 resource "terrifi_wlan" "test" {
   name       = %q
   passphrase = "testpassword123"
@@ -398,7 +401,7 @@ resource "terrifi_wlan" "test" {
 				Check: resource.TestCheckResourceAttr("terrifi_wlan.test", "enabled", "true"),
 			},
 			{
-				Config: wlanTestNetwork(netName, 517) + fmt.Sprintf(`
+				Config: wlanTestNetwork(netName, vlan) + fmt.Sprintf(`
 resource "terrifi_wlan" "test" {
   name       = %q
   passphrase = "testpassword123"
@@ -409,7 +412,7 @@ resource "terrifi_wlan" "test" {
 				Check: resource.TestCheckResourceAttr("terrifi_wlan.test", "enabled", "false"),
 			},
 			{
-				Config: wlanTestNetwork(netName, 517) + fmt.Sprintf(`
+				Config: wlanTestNetwork(netName, vlan) + fmt.Sprintf(`
 resource "terrifi_wlan" "test" {
   name       = %q
   passphrase = "testpassword123"
@@ -426,6 +429,7 @@ resource "terrifi_wlan" "test" {
 func TestAccWLAN_updateName(t *testing.T) {
 	requireHardware(t)
 	suffix := randomSuffix()
+	vlan := randomVLAN()
 	netName := fmt.Sprintf("tfacc-wlan-net-%s", suffix)
 	wlanName1 := fmt.Sprintf("tfacc-wlan-%s", suffix)
 	wlanName2 := fmt.Sprintf("tfacc-wlan-upd-%s", suffix)
@@ -435,7 +439,7 @@ func TestAccWLAN_updateName(t *testing.T) {
 		ProtoV6ProviderFactories: testAccProtoV6ProviderFactories,
 		Steps: []resource.TestStep{
 			{
-				Config: wlanTestNetwork(netName, 501) + fmt.Sprintf(`
+				Config: wlanTestNetwork(netName, vlan) + fmt.Sprintf(`
 resource "terrifi_wlan" "test" {
   name       = %q
   passphrase = "testpassword123"
@@ -445,7 +449,7 @@ resource "terrifi_wlan" "test" {
 				Check: resource.TestCheckResourceAttr("terrifi_wlan.test", "name", wlanName1),
 			},
 			{
-				Config: wlanTestNetwork(netName, 501) + fmt.Sprintf(`
+				Config: wlanTestNetwork(netName, vlan) + fmt.Sprintf(`
 resource "terrifi_wlan" "test" {
   name       = %q
   passphrase = "testpassword123"
@@ -461,6 +465,7 @@ resource "terrifi_wlan" "test" {
 func TestAccWLAN_updatePassphrase(t *testing.T) {
 	requireHardware(t)
 	suffix := randomSuffix()
+	vlan := randomVLAN()
 	netName := fmt.Sprintf("tfacc-wlan-net-%s", suffix)
 	wlanName := fmt.Sprintf("tfacc-wlan-%s", suffix)
 
@@ -469,7 +474,7 @@ func TestAccWLAN_updatePassphrase(t *testing.T) {
 		ProtoV6ProviderFactories: testAccProtoV6ProviderFactories,
 		Steps: []resource.TestStep{
 			{
-				Config: wlanTestNetwork(netName, 502) + fmt.Sprintf(`
+				Config: wlanTestNetwork(netName, vlan) + fmt.Sprintf(`
 resource "terrifi_wlan" "test" {
   name       = %q
   passphrase = "firstpassword1"
@@ -478,7 +483,7 @@ resource "terrifi_wlan" "test" {
 `, wlanName),
 			},
 			{
-				Config: wlanTestNetwork(netName, 502) + fmt.Sprintf(`
+				Config: wlanTestNetwork(netName, vlan) + fmt.Sprintf(`
 resource "terrifi_wlan" "test" {
   name       = %q
   passphrase = "secondpassword2"
@@ -493,6 +498,7 @@ resource "terrifi_wlan" "test" {
 func TestAccWLAN_updateBand(t *testing.T) {
 	requireHardware(t)
 	suffix := randomSuffix()
+	vlan := randomVLAN()
 	netName := fmt.Sprintf("tfacc-wlan-net-%s", suffix)
 	wlanName := fmt.Sprintf("tfacc-wlan-%s", suffix)
 
@@ -501,7 +507,7 @@ func TestAccWLAN_updateBand(t *testing.T) {
 		ProtoV6ProviderFactories: testAccProtoV6ProviderFactories,
 		Steps: []resource.TestStep{
 			{
-				Config: wlanTestNetwork(netName, 503) + fmt.Sprintf(`
+				Config: wlanTestNetwork(netName, vlan) + fmt.Sprintf(`
 resource "terrifi_wlan" "test" {
   name       = %q
   passphrase = "testpassword123"
@@ -512,7 +518,7 @@ resource "terrifi_wlan" "test" {
 				Check: resource.TestCheckResourceAttr("terrifi_wlan.test", "wifi_band", "2g"),
 			},
 			{
-				Config: wlanTestNetwork(netName, 503) + fmt.Sprintf(`
+				Config: wlanTestNetwork(netName, vlan) + fmt.Sprintf(`
 resource "terrifi_wlan" "test" {
   name       = %q
   passphrase = "testpassword123"
@@ -523,7 +529,7 @@ resource "terrifi_wlan" "test" {
 				Check: resource.TestCheckResourceAttr("terrifi_wlan.test", "wifi_band", "5g"),
 			},
 			{
-				Config: wlanTestNetwork(netName, 503) + fmt.Sprintf(`
+				Config: wlanTestNetwork(netName, vlan) + fmt.Sprintf(`
 resource "terrifi_wlan" "test" {
   name       = %q
   passphrase = "testpassword123"
@@ -540,6 +546,7 @@ resource "terrifi_wlan" "test" {
 func TestAccWLAN_hiddenSSID(t *testing.T) {
 	requireHardware(t)
 	suffix := randomSuffix()
+	vlan := randomVLAN()
 	netName := fmt.Sprintf("tfacc-wlan-net-%s", suffix)
 	wlanName := fmt.Sprintf("tfacc-wlan-%s", suffix)
 
@@ -548,7 +555,7 @@ func TestAccWLAN_hiddenSSID(t *testing.T) {
 		ProtoV6ProviderFactories: testAccProtoV6ProviderFactories,
 		Steps: []resource.TestStep{
 			{
-				Config: wlanTestNetwork(netName, 504) + fmt.Sprintf(`
+				Config: wlanTestNetwork(netName, vlan) + fmt.Sprintf(`
 resource "terrifi_wlan" "test" {
   name       = %q
   passphrase = "testpassword123"
@@ -559,7 +566,7 @@ resource "terrifi_wlan" "test" {
 				Check: resource.TestCheckResourceAttr("terrifi_wlan.test", "hide_ssid", "true"),
 			},
 			{
-				Config: wlanTestNetwork(netName, 504) + fmt.Sprintf(`
+				Config: wlanTestNetwork(netName, vlan) + fmt.Sprintf(`
 resource "terrifi_wlan" "test" {
   name       = %q
   passphrase = "testpassword123"
@@ -576,6 +583,7 @@ resource "terrifi_wlan" "test" {
 func TestAccWLAN_openSecurity(t *testing.T) {
 	requireHardware(t)
 	suffix := randomSuffix()
+	vlan := randomVLAN()
 	netName := fmt.Sprintf("tfacc-wlan-net-%s", suffix)
 	wlanName := fmt.Sprintf("tfacc-wlan-%s", suffix)
 
@@ -584,7 +592,7 @@ func TestAccWLAN_openSecurity(t *testing.T) {
 		ProtoV6ProviderFactories: testAccProtoV6ProviderFactories,
 		Steps: []resource.TestStep{
 			{
-				Config: wlanTestNetwork(netName, 505) + fmt.Sprintf(`
+				Config: wlanTestNetwork(netName, vlan) + fmt.Sprintf(`
 resource "terrifi_wlan" "test" {
   name       = %q
   network_id = terrifi_network.wlan_test.id
@@ -603,6 +611,7 @@ resource "terrifi_wlan" "test" {
 func TestAccWLAN_import(t *testing.T) {
 	requireHardware(t)
 	suffix := randomSuffix()
+	vlan := randomVLAN()
 	netName := fmt.Sprintf("tfacc-wlan-net-%s", suffix)
 	wlanName := fmt.Sprintf("tfacc-wlan-%s", suffix)
 
@@ -611,7 +620,7 @@ func TestAccWLAN_import(t *testing.T) {
 		ProtoV6ProviderFactories: testAccProtoV6ProviderFactories,
 		Steps: []resource.TestStep{
 			{
-				Config: wlanTestNetwork(netName, 506) + fmt.Sprintf(`
+				Config: wlanTestNetwork(netName, vlan) + fmt.Sprintf(`
 resource "terrifi_wlan" "test" {
   name       = %q
   passphrase = "testpassword123"
@@ -632,6 +641,7 @@ resource "terrifi_wlan" "test" {
 func TestAccWLAN_importSiteID(t *testing.T) {
 	requireHardware(t)
 	suffix := randomSuffix()
+	vlan := randomVLAN()
 	netName := fmt.Sprintf("tfacc-wlan-net-%s", suffix)
 	wlanName := fmt.Sprintf("tfacc-wlan-%s", suffix)
 
@@ -640,7 +650,7 @@ func TestAccWLAN_importSiteID(t *testing.T) {
 		ProtoV6ProviderFactories: testAccProtoV6ProviderFactories,
 		Steps: []resource.TestStep{
 			{
-				Config: wlanTestNetwork(netName, 507) + fmt.Sprintf(`
+				Config: wlanTestNetwork(netName, vlan) + fmt.Sprintf(`
 resource "terrifi_wlan" "test" {
   name       = %q
   passphrase = "testpassword123"
@@ -668,10 +678,11 @@ resource "terrifi_wlan" "test" {
 func TestAccWLAN_idempotentReapply(t *testing.T) {
 	requireHardware(t)
 	suffix := randomSuffix()
+	vlan := randomVLAN()
 	netName := fmt.Sprintf("tfacc-wlan-net-%s", suffix)
 	wlanName := fmt.Sprintf("tfacc-wlan-%s", suffix)
 
-	config := wlanTestNetwork(netName, 508) + fmt.Sprintf(`
+	config := wlanTestNetwork(netName, vlan) + fmt.Sprintf(`
 resource "terrifi_wlan" "test" {
   name       = %q
   passphrase = "testpassword123"
@@ -703,6 +714,7 @@ resource "terrifi_wlan" "test" {
 func TestAccWLAN_updateSecurityOpenToWpapsk(t *testing.T) {
 	requireHardware(t)
 	suffix := randomSuffix()
+	vlan := randomVLAN()
 	netName := fmt.Sprintf("tfacc-wlan-net-%s", suffix)
 	wlanName := fmt.Sprintf("tfacc-wlan-%s", suffix)
 
@@ -711,7 +723,7 @@ func TestAccWLAN_updateSecurityOpenToWpapsk(t *testing.T) {
 		ProtoV6ProviderFactories: testAccProtoV6ProviderFactories,
 		Steps: []resource.TestStep{
 			{
-				Config: wlanTestNetwork(netName, 510) + fmt.Sprintf(`
+				Config: wlanTestNetwork(netName, vlan) + fmt.Sprintf(`
 resource "terrifi_wlan" "test" {
   name       = %q
   network_id = terrifi_network.wlan_test.id
@@ -723,7 +735,7 @@ resource "terrifi_wlan" "test" {
 				),
 			},
 			{
-				Config: wlanTestNetwork(netName, 510) + fmt.Sprintf(`
+				Config: wlanTestNetwork(netName, vlan) + fmt.Sprintf(`
 resource "terrifi_wlan" "test" {
   name       = %q
   passphrase = "newpassword123"
@@ -742,6 +754,7 @@ resource "terrifi_wlan" "test" {
 func TestAccWLAN_updateSecurityWpapskToOpen(t *testing.T) {
 	requireHardware(t)
 	suffix := randomSuffix()
+	vlan := randomVLAN()
 	netName := fmt.Sprintf("tfacc-wlan-net-%s", suffix)
 	wlanName := fmt.Sprintf("tfacc-wlan-%s", suffix)
 
@@ -750,7 +763,7 @@ func TestAccWLAN_updateSecurityWpapskToOpen(t *testing.T) {
 		ProtoV6ProviderFactories: testAccProtoV6ProviderFactories,
 		Steps: []resource.TestStep{
 			{
-				Config: wlanTestNetwork(netName, 511) + fmt.Sprintf(`
+				Config: wlanTestNetwork(netName, vlan) + fmt.Sprintf(`
 resource "terrifi_wlan" "test" {
   name       = %q
   passphrase = "testpassword123"
@@ -761,7 +774,7 @@ resource "terrifi_wlan" "test" {
 				Check: resource.TestCheckResourceAttr("terrifi_wlan.test", "security", "wpapsk"),
 			},
 			{
-				Config: wlanTestNetwork(netName, 511) + fmt.Sprintf(`
+				Config: wlanTestNetwork(netName, vlan) + fmt.Sprintf(`
 resource "terrifi_wlan" "test" {
   name       = %q
   network_id = terrifi_network.wlan_test.id
@@ -777,6 +790,8 @@ resource "terrifi_wlan" "test" {
 func TestAccWLAN_updateNetwork(t *testing.T) {
 	requireHardware(t)
 	suffix := randomSuffix()
+	vlan1 := randomVLAN()
+	vlan2 := randomVLAN()
 	netName1 := fmt.Sprintf("tfacc-wlan-net1-%s", suffix)
 	netName2 := fmt.Sprintf("tfacc-wlan-net2-%s", suffix)
 	wlanName := fmt.Sprintf("tfacc-wlan-%s", suffix)
@@ -785,23 +800,23 @@ func TestAccWLAN_updateNetwork(t *testing.T) {
 resource "terrifi_network" "net1" {
   name          = %q
   purpose       = "corporate"
-  vlan_id       = 512
-  subnet        = "10.2.0.1/24"
+  vlan_id       = %d
+  subnet        = "10.%d.%d.1/24"
   network_group = "LAN"
   dhcp_enabled  = false
 }
-`, netName1)
+`, netName1, vlan1, vlan1/256, vlan1%256)
 
 	net2 := fmt.Sprintf(`
 resource "terrifi_network" "net2" {
   name          = %q
   purpose       = "corporate"
-  vlan_id       = 513
-  subnet        = "10.2.1.1/24"
+  vlan_id       = %d
+  subnet        = "10.%d.%d.1/24"
   network_group = "LAN"
   dhcp_enabled  = false
 }
-`, netName2)
+`, netName2, vlan2, vlan2/256, vlan2%256)
 
 	resource.Test(t, resource.TestCase{
 		PreCheck:                 func() { preCheck(t) },
@@ -840,6 +855,7 @@ resource "terrifi_wlan" "test" {
 func TestAccWLAN_updateMultipleProperties(t *testing.T) {
 	requireHardware(t)
 	suffix := randomSuffix()
+	vlan := randomVLAN()
 	netName := fmt.Sprintf("tfacc-wlan-net-%s", suffix)
 	wlanName1 := fmt.Sprintf("tfacc-wlan-%s", suffix)
 	wlanName2 := fmt.Sprintf("tfacc-wlan-upd-%s", suffix)
@@ -849,7 +865,7 @@ func TestAccWLAN_updateMultipleProperties(t *testing.T) {
 		ProtoV6ProviderFactories: testAccProtoV6ProviderFactories,
 		Steps: []resource.TestStep{
 			{
-				Config: wlanTestNetwork(netName, 514) + fmt.Sprintf(`
+				Config: wlanTestNetwork(netName, vlan) + fmt.Sprintf(`
 resource "terrifi_wlan" "test" {
   name       = %q
   passphrase = "testpassword123"
@@ -865,7 +881,7 @@ resource "terrifi_wlan" "test" {
 				),
 			},
 			{
-				Config: wlanTestNetwork(netName, 514) + fmt.Sprintf(`
+				Config: wlanTestNetwork(netName, vlan) + fmt.Sprintf(`
 resource "terrifi_wlan" "test" {
   name       = %q
   passphrase = "changedpassword1"
@@ -887,6 +903,7 @@ resource "terrifi_wlan" "test" {
 func TestAccWLAN_updateWpaMode(t *testing.T) {
 	requireHardware(t)
 	suffix := randomSuffix()
+	vlan := randomVLAN()
 	netName := fmt.Sprintf("tfacc-wlan-net-%s", suffix)
 	wlanName := fmt.Sprintf("tfacc-wlan-%s", suffix)
 
@@ -895,7 +912,7 @@ func TestAccWLAN_updateWpaMode(t *testing.T) {
 		ProtoV6ProviderFactories: testAccProtoV6ProviderFactories,
 		Steps: []resource.TestStep{
 			{
-				Config: wlanTestNetwork(netName, 515) + fmt.Sprintf(`
+				Config: wlanTestNetwork(netName, vlan) + fmt.Sprintf(`
 resource "terrifi_wlan" "test" {
   name       = %q
   passphrase = "testpassword123"
@@ -906,7 +923,7 @@ resource "terrifi_wlan" "test" {
 				Check: resource.TestCheckResourceAttr("terrifi_wlan.test", "wpa_mode", "wpa2"),
 			},
 			{
-				Config: wlanTestNetwork(netName, 515) + fmt.Sprintf(`
+				Config: wlanTestNetwork(netName, vlan) + fmt.Sprintf(`
 resource "terrifi_wlan" "test" {
   name       = %q
   passphrase = "testpassword123"
@@ -917,7 +934,7 @@ resource "terrifi_wlan" "test" {
 				Check: resource.TestCheckResourceAttr("terrifi_wlan.test", "wpa_mode", "auto"),
 			},
 			{
-				Config: wlanTestNetwork(netName, 515) + fmt.Sprintf(`
+				Config: wlanTestNetwork(netName, vlan) + fmt.Sprintf(`
 resource "terrifi_wlan" "test" {
   name       = %q
   passphrase = "testpassword123"
@@ -934,6 +951,7 @@ resource "terrifi_wlan" "test" {
 func TestAccWLAN_wpa3(t *testing.T) {
 	requireHardware(t)
 	suffix := randomSuffix()
+	vlan := randomVLAN()
 	netName := fmt.Sprintf("tfacc-wlan-net-%s", suffix)
 	wlanName := fmt.Sprintf("tfacc-wlan-%s", suffix)
 
@@ -942,7 +960,7 @@ func TestAccWLAN_wpa3(t *testing.T) {
 		ProtoV6ProviderFactories: testAccProtoV6ProviderFactories,
 		Steps: []resource.TestStep{
 			{
-				Config: wlanTestNetwork(netName, 509) + fmt.Sprintf(`
+				Config: wlanTestNetwork(netName, vlan) + fmt.Sprintf(`
 resource "terrifi_wlan" "test" {
   name            = %q
   passphrase      = "testpassword123"
@@ -957,7 +975,7 @@ resource "terrifi_wlan" "test" {
 				),
 			},
 			{
-				Config: wlanTestNetwork(netName, 509) + fmt.Sprintf(`
+				Config: wlanTestNetwork(netName, vlan) + fmt.Sprintf(`
 resource "terrifi_wlan" "test" {
   name            = %q
   passphrase      = "testpassword123"


### PR DESCRIPTION
## Summary
- Fix server-side race condition in UniFi controller when multiple firewall zones are updated concurrently (e.g., moving a network between zones). The Update method now verifies the result via a read-back and retries the PUT if the persisted state doesn't match.
- Randomize all hardcoded test VLANs in firewall zone and WLAN tests to prevent `api.err.VlanUsed` collisions from leftover resources after timeout-failed cleanups.

## Test plan
- [x] Ran `task test:acc:hardware` multiple times — all code-related flakes are resolved
- [x] `TestAccFirewallZone_moveNetworkBetweenZones` passed 5 consecutive times (previously failed ~60% of the time)
- [x] CI HIL workflow should pass on LAN connection without transient i/o timeouts

🤖 Generated with [Claude Code](https://claude.com/claude-code)