### PR TITLE
Fix client device fixed_ip handling: prevent 400 error and allow network_override_id

### DIFF
--- a/docs/resources/client_device.md
+++ b/docs/resources/client_device.md
@@ -41,6 +41,19 @@ resource "terrifi_client_device" "server" {
 }
 ```
 
+### Fixed IP with network override
+
+When using a network override, `network_id` is not required — the override provides the network context.
+
+```terraform
+resource "terrifi_client_device" "laptop" {
+  mac                 = "22:33:44:55:66:77"
+  name                = "Work Laptop"
+  fixed_ip            = "192.168.10.20"
+  network_override_id = terrifi_network.lan.id
+}
+```
+
 ### Local DNS record
 
 Local DNS records require a fixed IP assignment (controller requirement).
@@ -75,8 +88,8 @@ resource "terrifi_client_device" "blocked" {
 
 - `name` (String) — The alias/display name for the client device.
 - `note` (String) — A free-text note for the client device.
-- `fixed_ip` (String) — A fixed IP address to assign via DHCP reservation. Requires `network_id`.
-- `network_id` (String) — The network ID for fixed IP assignment. Required when `fixed_ip` is set.
+- `fixed_ip` (String) — A fixed IP address to assign via DHCP reservation. Requires `network_id` or `network_override_id`.
+- `network_id` (String) — The network ID for fixed IP assignment. Required when `fixed_ip` is set unless `network_override_id` provides the network context.
 - `network_override_id` (String) — The network ID for VLAN/network override.
 - `local_dns_record` (String) — A local DNS hostname for this client device. Requires `fixed_ip`.
 - `client_group_id` (String) — The ID of the client group to assign this device to. Use `terrifi_client_group` to manage groups.

--- a/internal/provider/client_device_resource.go
+++ b/internal/provider/client_device_resource.go
@@ -20,8 +20,9 @@ import (
 var macRegexp = regexp.MustCompile(`^([0-9A-Fa-f]{2}:){5}[0-9A-Fa-f]{2}$`)
 
 var (
-	_ resource.Resource                = &clientDeviceResource{}
-	_ resource.ResourceWithImportState = &clientDeviceResource{}
+	_ resource.Resource                     = &clientDeviceResource{}
+	_ resource.ResourceWithImportState      = &clientDeviceResource{}
+	_ resource.ResourceWithConfigValidators = &clientDeviceResource{}
 )
 
 func NewClientDeviceResource() resource.Resource {
@@ -108,16 +109,14 @@ func (r *clientDeviceResource) Schema(
 
 			"fixed_ip": schema.StringAttribute{
 				MarkdownDescription: "A fixed IP address to assign to this client via DHCP reservation. " +
-					"Requires `network_id` to also be set.",
+					"Requires `network_id` or `network_override_id` to also be set.",
 				Optional: true,
-				Validators: []validator.String{
-					stringvalidator.AlsoRequires(path.MatchRoot("network_id")),
-				},
 			},
 
 			"network_id": schema.StringAttribute{
-				MarkdownDescription: "The network ID for fixed IP assignment. Required when `fixed_ip` is set.",
-				Optional:            true,
+				MarkdownDescription: "The network ID for fixed IP assignment. " +
+					"Required when `fixed_ip` is set unless `network_override_id` provides the network context.",
+				Optional: true,
 				Validators: []validator.String{
 					stringvalidator.LengthAtLeast(1),
 				},
@@ -155,6 +154,12 @@ func (r *clientDeviceResource) Schema(
 	}
 }
 
+func (r *clientDeviceResource) ConfigValidators(_ context.Context) []resource.ConfigValidator {
+	return []resource.ConfigValidator{
+		clientDeviceFixedIPNetworkValidator{},
+	}
+}
+
 func (r *clientDeviceResource) Configure(
 	_ context.Context,
 	req resource.ConfigureRequest,
@@ -187,9 +192,13 @@ func (r *clientDeviceResource) Create(
 		return
 	}
 
-	// Save client_group_id before the API call — the API doesn't return
-	// usergroup_id in create/update responses, so we restore it after apiToModel.
+	// Save fields before the API call that need to be restored after
+	// apiToModel because the API response may differ from the user's config:
+	// - client_group_id: the API doesn't return usergroup_id in responses
+	// - network_id: when fixed_ip uses network_override_id as fallback, the
+	//   API returns network_id but the user didn't configure it
 	plannedGroupID := plan.ClientGroupID
+	plannedNetworkID := plan.NetworkID
 
 	site := r.client.SiteOrDefault(plan.Site)
 	apiObj := r.modelToAPI(&plan)
@@ -202,6 +211,7 @@ func (r *clientDeviceResource) Create(
 
 	r.apiToModel(created, &plan, site)
 	plan.ClientGroupID = plannedGroupID
+	plan.NetworkID = plannedNetworkID
 	resp.Diagnostics.Append(resp.State.Set(ctx, &plan)...)
 }
 
@@ -216,9 +226,9 @@ func (r *clientDeviceResource) Read(
 		return
 	}
 
-	// Save client_group_id before the API call — the API doesn't return
-	// usergroup_id in responses, so we preserve it from prior state.
+	// Save fields before the API call that need to be restored after apiToModel.
 	priorGroupID := state.ClientGroupID
+	priorNetworkID := state.NetworkID
 
 	site := r.client.SiteOrDefault(state.Site)
 
@@ -237,6 +247,7 @@ func (r *clientDeviceResource) Read(
 
 	r.apiToModel(apiObj, &state, site)
 	state.ClientGroupID = priorGroupID
+	state.NetworkID = priorNetworkID
 	resp.Diagnostics.Append(resp.State.Set(ctx, &state)...)
 }
 
@@ -252,9 +263,9 @@ func (r *clientDeviceResource) Update(
 		return
 	}
 
-	// Save client_group_id before the API call — the API doesn't return
-	// usergroup_id in create/update responses, so we restore it after apiToModel.
+	// Save fields before the API call that need to be restored after apiToModel.
 	plannedGroupID := plan.ClientGroupID
+	plannedNetworkID := plan.NetworkID
 
 	r.applyPlanToState(&plan, &state)
 
@@ -283,6 +294,7 @@ func (r *clientDeviceResource) Update(
 			}
 			r.apiToModel(updated, &state, site)
 			state.ClientGroupID = plannedGroupID
+			state.NetworkID = plannedNetworkID
 			resp.Diagnostics.Append(resp.State.Set(ctx, &state)...)
 			return
 		}
@@ -292,6 +304,7 @@ func (r *clientDeviceResource) Update(
 
 	r.apiToModel(updated, &state, site)
 	state.ClientGroupID = plannedGroupID
+	state.NetworkID = plannedNetworkID
 	resp.Diagnostics.Append(resp.State.Set(ctx, &state)...)
 }
 
@@ -360,6 +373,51 @@ func (r *clientDeviceResource) ImportState(
 	}
 
 	resource.ImportStatePassthroughID(ctx, path.Root("id"), req, resp)
+}
+
+// ---------------------------------------------------------------------------
+// Config validators
+// ---------------------------------------------------------------------------
+
+// clientDeviceFixedIPNetworkValidator ensures that when fixed_ip is specified,
+// at least one of network_id or network_override_id is also specified.
+type clientDeviceFixedIPNetworkValidator struct{}
+
+func (v clientDeviceFixedIPNetworkValidator) Description(_ context.Context) string {
+	return "When fixed_ip is specified, either network_id or network_override_id must also be specified."
+}
+
+func (v clientDeviceFixedIPNetworkValidator) MarkdownDescription(ctx context.Context) string {
+	return v.Description(ctx)
+}
+
+func (v clientDeviceFixedIPNetworkValidator) ValidateResource(ctx context.Context, req resource.ValidateConfigRequest, resp *resource.ValidateConfigResponse) {
+	var fixedIP, networkID, networkOverrideID types.String
+
+	resp.Diagnostics.Append(req.Config.GetAttribute(ctx, path.Root("fixed_ip"), &fixedIP)...)
+	resp.Diagnostics.Append(req.Config.GetAttribute(ctx, path.Root("network_id"), &networkID)...)
+	resp.Diagnostics.Append(req.Config.GetAttribute(ctx, path.Root("network_override_id"), &networkOverrideID)...)
+
+	if resp.Diagnostics.HasError() {
+		return
+	}
+
+	if fixedIP.IsNull() || fixedIP.IsUnknown() {
+		return
+	}
+
+	// Treat unknown values (e.g. references to other resources) as "set" —
+	// the user configured the attribute, the value is just not resolved yet.
+	networkIDSet := !networkID.IsNull()
+	networkOverrideIDSet := !networkOverrideID.IsNull()
+
+	if !networkIDSet && !networkOverrideIDSet {
+		resp.Diagnostics.AddAttributeError(
+			path.Root("fixed_ip"),
+			"Missing Network Attribute",
+			"Attribute \"network_id\" or \"network_override_id\" must be specified when \"fixed_ip\" is specified.",
+		)
+	}
 }
 
 // ---------------------------------------------------------------------------


### PR DESCRIPTION
Closes #47, closes #42. Supersedes #49.

## Summary
- **Fix #47 (import 400 "not found: type=")**: `buildClientDeviceRequest` now requires a valid network ID before setting `use_fixedip=true`. Previously it only checked `fixed_ip`, sending an invalid request when `network_id` was empty (e.g. from a generate-imports TODO placeholder).
- **Fix #42 (allow fixed_ip with network_override_id)**: Replaced the strict `AlsoRequires(network_id)` validator on `fixed_ip` with a `ConfigValidator` that accepts either `network_id` or `network_override_id` (or both). When only `network_override_id` is provided, `buildClientDeviceRequest` falls back to using it as the `network_id` in the API request.
- Added `LengthAtLeast(1)` validators to `network_id` and `network_override_id` to reject empty strings at plan time.
- Preserve the user's null `network_id` through Create/Read/Update so Terraform doesn't report an inconsistent result when the override fallback is used.
- Updated docs with a new "Fixed IP with network override" example and updated attribute descriptions.
- Added unit tests for `buildClientDeviceRequest` (7 cases including override fallback and preference) and `modelToAPI` edge cases.
- Added 4 new acceptance tests: `fixedIPWithNetworkOverride`, `updateFixedIPNetworkToOverride`, `networkOverrideWithFixedIP`, `networkOverrideOnly`.

## Test plan
- [x] All unit tests pass (`task test:unit`)
- [x] All 18 client device HIL tests pass (`task test:acc:hardware -- -run TestAccClientDevice`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)