### PR TITLE
Cache Docker images in CI to avoid rate limits

### DIFF
--- a/.github/workflows/ci-local.yaml
+++ b/.github/workflows/ci-local.yaml
@@ -46,9 +46,30 @@ jobs:
       - name: Unit tests
         timeout-minutes: 1
         run: task test:unit
+      - name: Compute Docker image cache key
+        id: docker-image-key
+        run: echo "hash=$(grep 'image:' docker-compose.yaml | sha256sum | cut -d' ' -f1)" >> "$GITHUB_OUTPUT"
+      - name: Cache Docker images
+        uses: actions/cache@v4
+        id: docker-cache
+        with:
+          path: /tmp/docker-images
+          key: docker-images-${{ steps.docker-image-key.outputs.hash }}
+      - name: Load cached Docker images
+        if: steps.docker-cache.outputs.cache-hit == 'true'
+        timeout-minutes: 1
+        run: |
+          for img in /tmp/docker-images/*.tar; do
+            docker load -i "$img"
+          done
       - name: Pull Docker images
+        if: steps.docker-cache.outputs.cache-hit != 'true'
         timeout-minutes: 10
-        run: docker compose -f docker-compose.yaml pull --quiet
+        run: |
+          docker compose -f docker-compose.yaml pull --quiet
+          mkdir -p /tmp/docker-images
+          docker save mongo:8.2 -o /tmp/docker-images/mongo.tar
+          docker save lscr.io/linuxserver/unifi-network-application:version-10.1.85 -o /tmp/docker-images/unifi.tar
       - name: Acceptance tests (Docker)
         timeout-minutes: 10
         run: task test:acc


### PR DESCRIPTION
## Summary
- Cache Docker images (`mongo:8.2`, `unifi-network-application`) as tarballs in the GitHub Actions cache to avoid Docker Hub's unauthenticated rate limit (10 pulls/hour)
- Cache key is derived from the `image:` lines in `docker-compose.yaml`, so it only busts when image versions change (not on unrelated compose file edits)
- On cache hit: `docker load` from local tarballs (~5-10s). On cache miss: pulls normally, then saves tarballs for next run

Closes #50

## Test plan
- [ ] Merge and verify the first CI run pulls and saves to cache (cache miss path)
- [ ] Verify a subsequent CI run loads from cache without pulling (cache hit path)
- [ ] Bump an image version in `docker-compose.yaml` and verify the cache invalidates

🤖 Generated with [Claude Code](https://claude.com/claude-code)