### PR TITLE
Fix CLI --version for go install builds

### DIFF
--- a/cmd/terrifi/main.go
+++ b/cmd/terrifi/main.go
@@ -3,6 +3,7 @@ package main
 import (
 	"fmt"
 	"os"
+	"runtime/debug"
 
 	"github.com/spf13/cobra"
 )
@@ -11,8 +12,17 @@ import (
 //
 //	go build -ldflags "-X main.version=v1.0.0"
 //
-// GoReleaser sets this automatically.
+// GoReleaser sets this automatically. For `go install ...@<version>` builds,
+// the version is read from the embedded Go module build info as a fallback.
 var version = "dev"
+
+func init() {
+	if version == "dev" {
+		if info, ok := debug.ReadBuildInfo(); ok && info.Main.Version != "" && info.Main.Version != "(devel)" {
+			version = info.Main.Version
+		}
+	}
+}
 
 func main() {
 	rootCmd := &cobra.Command{


### PR DESCRIPTION
## Summary

- `terrifi --version` reported `dev` when installed via `go install ...@<version>` because the version was only injected via ldflags by GoReleaser
- Added a fallback that reads the version from Go's embedded module build info (`runtime/debug.ReadBuildInfo`), which Go populates automatically for `go install` builds

## How it works across build paths

| Build method | Result |
|---|---|
| GoReleaser release | ldflags sets version, fallback is a no-op |
| `go install ...@v0.2.0-RC1` | Reads `v0.2.0-RC1` from build info |
| Local `go build` | Stays `dev` (build info reports `(devel)`, filtered out) |

Closes #57

## Test plan

- [ ] `go build ./cmd/terrifi/ && ./terrifi --version` → `terrifi version dev`
- [ ] `go install github.com/alexklibisz/terrifi/cmd/terrifi@<tag>` → reports the tag version

🤖 Generated with [Claude Code](https://claude.com/claude-code)