### PR TITLE
Omit network_id from generate-imports when network_override_id is set

### DIFF
--- a/internal/generate/client_device.go
+++ b/internal/generate/client_device.go
@@ -28,11 +28,15 @@ func ClientDeviceBlocks(clients []unifi.Client) []ResourceBlock {
 		}
 		if c.UseFixedIP && c.FixedIP != "" {
 			block.Attributes = append(block.Attributes, Attr{Key: "fixed_ip", Value: HCLString(c.FixedIP)})
-			block.Attributes = append(block.Attributes, Attr{
-				Key:     "network_id",
-				Value:   HCLString(c.NetworkID),
-				Comment: "TODO: find and reference corresponding terrifi_network resource",
-			})
+			// Only emit network_id when network_override_id is not providing the network context.
+			hasNetworkOverride := c.VirtualNetworkOverrideEnabled != nil && *c.VirtualNetworkOverrideEnabled && c.VirtualNetworkOverrideID != ""
+			if !hasNetworkOverride {
+				block.Attributes = append(block.Attributes, Attr{
+					Key:     "network_id",
+					Value:   HCLString(c.NetworkID),
+					Comment: "TODO: find and reference corresponding terrifi_network resource",
+				})
+			}
 		}
 		if c.LocalDNSRecordEnabled && c.LocalDNSRecord != "" {
 			block.Attributes = append(block.Attributes, Attr{Key: "local_dns_record", Value: HCLString(c.LocalDNSRecord)})


### PR DESCRIPTION
## Summary
- Fixes #58
- When a client device has `network_override_id` set, `generate-imports` no longer emits an empty `network_id` attribute
- Only one of `network_id` or `network_override_id` is required alongside `fixed_ip`, so emitting both was incorrect

## Test plan
- [x] Updated `TestClientDeviceBlocks` to assert `network_id` is omitted when `network_override_id` is present
- [x] Added `TestClientDeviceBlocks_fixedIPWithNetworkID` to verify `network_id` is still emitted when there is no override
- [x] All existing generate package tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)