### PR TITLE
Make firewall policy index computed-only

### DIFF
--- a/docs/resources/firewall_policy.md
+++ b/docs/resources/firewall_policy.md
@@ -121,13 +121,13 @@ resource "terrifi_firewall_policy" "weekday_block" {
 - `match_ipsec` (Boolean) — Whether to match IPsec traffic.
 - `logging` (Boolean) — Whether to enable syslog logging for matched traffic.
 - `create_allow_respond` (Boolean) — Whether to create a corresponding allow-respond rule.
-- `index` (Number) — Ordering index. Assigned by the controller if not specified.
 - `schedule` (Block) — Schedule configuration. See [Schedule](#schedule) below.
 - `site` (String) — The site. Defaults to the provider site. Changing this forces a new resource.
 
 ### Read-Only
 
 - `id` (String) — The ID of the firewall policy.
+- `index` (Number) — The ordering index of the policy, assigned by the controller.
 
 ### Source/Destination
 

--- a/internal/generate/firewall_policy.go
+++ b/internal/generate/firewall_policy.go
@@ -46,10 +46,6 @@ func FirewallPolicyBlocks(policies []*unifi.FirewallPolicy) []ResourceBlock {
 		if p.CreateAllowRespond {
 			block.Attributes = append(block.Attributes, Attr{Key: "create_allow_respond", Value: HCLBool(true)})
 		}
-		if p.Index != nil {
-			block.Attributes = append(block.Attributes, Attr{Key: "index", Value: HCLInt64(*p.Index)})
-		}
-
 		if p.Source != nil {
 			block.Blocks = append(block.Blocks, buildEndpointBlock("source", p.Source.ZoneID, p.Source.MatchingTarget, p.Source.IPs, p.Source.PortMatchingType, p.Source.Port, p.Source.PortGroupID))
 		}

--- a/internal/generate/generate_test.go
+++ b/internal/generate/generate_test.go
@@ -375,7 +375,9 @@ func TestFirewallPolicyBlocks(t *testing.T) {
 	assert.Equal(t, `"ALLOW"`, attrs["action"])
 	assert.Equal(t, `"tcp"`, attrs["protocol"])
 	assert.Equal(t, "true", attrs["logging"])
-	assert.Equal(t, "5", attrs["index"])
+	// index is computed-only and should not appear in generated HCL
+	_, hasIndex := attrs["index"]
+	assert.False(t, hasIndex)
 	// ip_version should be omitted when BOTH
 	_, hasIPVersion := attrs["ip_version"]
 	assert.False(t, hasIPVersion)

--- a/internal/provider/firewall_policy_resource.go
+++ b/internal/provider/firewall_policy_resource.go
@@ -251,8 +251,7 @@ func (r *firewallPolicyResource) Schema(
 			},
 
 			"index": schema.Int64Attribute{
-				MarkdownDescription: "The ordering index of the policy. Assigned by the controller if not specified.",
-				Optional:            true,
+				MarkdownDescription: "The ordering index of the policy, assigned by the controller.",
 				Computed:            true,
 			},
 		},


### PR DESCRIPTION
## Summary

Fixes #70.

- The UniFi controller ignores user-provided `index` values on firewall policies and always assigns its own ordering index. When users specified `index` in their config, the controller returned a different value, causing the "inconsistent result after apply" error.
- Makes the `index` attribute computed-only (read-only) so Terraform accepts whatever the controller assigns. Removes `index` from `generate-imports` output since it can no longer be set in HCL config.
- Adds two new acceptance tests: `TestAccFirewallPolicy_indexComputed` (verifies computed index is stable) and `TestAccFirewallPolicy_createAllowRespond` (reproduces the exact scenario from the issue with `create_allow_respond = true`).

## Test plan

- [x] All unit tests pass (`task test:unit`)
- [x] All 93 hardware acceptance tests pass (`task test:acc:hardware`), including 2 new tests

🤖 Generated with [Claude Code](https://claude.com/claude-code)