### PR TITLE
Fix removing `blocked` from client_device config causing error

### DIFF
--- a/docs/resources/client_device.md
+++ b/docs/resources/client_device.md
@@ -111,7 +111,7 @@ resource "terrifi_client_device" "blocked" {
 - `network_override_id` (String) — The network ID for VLAN/network override.
 - `local_dns_record` (String) — A local DNS hostname for this client device. Requires `fixed_ip`.
 - `client_group_ids` (Set of String) — Set of client group IDs to assign this device to. Use `terrifi_client_group` to manage groups.
-- `blocked` (Boolean) — Whether the client device is blocked from network access.
+- `blocked` (Boolean) — Whether the client device is blocked from network access. Defaults to `false`.
 - `site` (String) — The site to associate the client device with. Defaults to the provider site. Changing this forces a new resource.
 
 ### Read-Only

--- a/internal/provider/client_device_resource.go
+++ b/internal/provider/client_device_resource.go
@@ -11,6 +11,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-framework/path"
 	"github.com/hashicorp/terraform-plugin-framework/resource"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema"
+	"github.com/hashicorp/terraform-plugin-framework/resource/schema/booldefault"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema/planmodifier"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema/stringplanmodifier"
 	"github.com/hashicorp/terraform-plugin-framework/schema/validator"
@@ -149,8 +150,10 @@ func (r *clientDeviceResource) Schema(
 			},
 
 			"blocked": schema.BoolAttribute{
-				MarkdownDescription: "Whether the client device is blocked from network access.",
+				MarkdownDescription: "Whether the client device is blocked from network access. Defaults to `false`.",
 				Optional:            true,
+				Computed:            true,
+				Default:             booldefault.StaticBool(false),
 			},
 		},
 	}
@@ -558,11 +561,11 @@ func (r *clientDeviceResource) apiToModel(c *unifi.Client, m *clientDeviceResour
 		m.ClientGroupIDs = types.SetNull(types.StringType)
 	}
 
-	// Preserve blocked state faithfully: true or false when explicitly set by
-	// the API, null when the API doesn't return the field at all.
+	// Treat nil Blocked as false — the absence of the field in the API
+	// response means the device is not blocked.
 	if c.Blocked != nil {
 		m.Blocked = types.BoolValue(*c.Blocked)
 	} else {
-		m.Blocked = types.BoolNull()
+		m.Blocked = types.BoolValue(false)
 	}
 }

--- a/internal/provider/client_device_resource_test.go
+++ b/internal/provider/client_device_resource_test.go
@@ -383,7 +383,7 @@ func TestClientDeviceAPIToModel(t *testing.T) {
 		assert.True(t, model.NetworkOverrideID.IsNull(), "NetworkOverrideID should be null")
 		assert.True(t, model.LocalDNSRecord.IsNull(), "LocalDNSRecord should be null")
 		assert.True(t, model.ClientGroupIDs.IsNull(), "ClientGroupIDs should be null")
-		assert.True(t, model.Blocked.IsNull(), "Blocked should be null")
+		assert.False(t, model.Blocked.ValueBool(), "Blocked should default to false")
 	})
 
 	t.Run("full client", func(t *testing.T) {
@@ -480,7 +480,7 @@ func TestClientDeviceAPIToModel(t *testing.T) {
 		var model clientDeviceResourceModel
 		r.apiToModel(c, &model, "default")
 
-		assert.True(t, model.Blocked.IsNull(), "Blocked should be null when nil")
+		assert.False(t, model.Blocked.ValueBool(), "Blocked should be false when nil")
 	})
 
 	t.Run("blocked false", func(t *testing.T) {
@@ -1181,6 +1181,95 @@ resource "terrifi_client_device" "test" {
 				Check: resource.ComposeTestCheckFunc(
 					resource.TestCheckResourceAttr("terrifi_client_device.test", "blocked", "false"),
 				),
+			},
+		},
+	})
+}
+
+func TestAccClientDevice_blockedAddRemove(t *testing.T) {
+	mac := randomMAC()
+	resource.Test(t, resource.TestCase{
+		PreCheck:                 func() { preCheck(t) },
+		ProtoV6ProviderFactories: testAccProtoV6ProviderFactories,
+		Steps: []resource.TestStep{
+			// Step 1: Create with blocked = true
+			{
+				Config: fmt.Sprintf(`
+resource "terrifi_client_device" "test" {
+  mac     = %q
+  name    = "tfacc-blocked-ar"
+  blocked = true
+}
+`, mac),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr("terrifi_client_device.test", "blocked", "true"),
+				),
+			},
+			// Step 2: Update to blocked = false
+			{
+				Config: fmt.Sprintf(`
+resource "terrifi_client_device" "test" {
+  mac     = %q
+  name    = "tfacc-blocked-ar"
+  blocked = false
+}
+`, mac),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr("terrifi_client_device.test", "blocked", "false"),
+				),
+			},
+			// Step 3: Remove blocked from config entirely — should default to false, no diff
+			{
+				Config: fmt.Sprintf(`
+resource "terrifi_client_device" "test" {
+  mac  = %q
+  name = "tfacc-blocked-ar"
+}
+`, mac),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr("terrifi_client_device.test", "blocked", "false"),
+				),
+			},
+			// Step 4: Add blocked = true back
+			{
+				Config: fmt.Sprintf(`
+resource "terrifi_client_device" "test" {
+  mac     = %q
+  name    = "tfacc-blocked-ar"
+  blocked = true
+}
+`, mac),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr("terrifi_client_device.test", "blocked", "true"),
+				),
+			},
+		},
+	})
+}
+
+func TestAccClientDevice_blockedDefaultFalse(t *testing.T) {
+	mac := randomMAC()
+	config := fmt.Sprintf(`
+resource "terrifi_client_device" "test" {
+  mac  = %q
+  name = "tfacc-blocked-default"
+}
+`, mac)
+	resource.Test(t, resource.TestCase{
+		PreCheck:                 func() { preCheck(t) },
+		ProtoV6ProviderFactories: testAccProtoV6ProviderFactories,
+		Steps: []resource.TestStep{
+			// Step 1: Create without blocked — should default to false
+			{
+				Config: config,
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr("terrifi_client_device.test", "blocked", "false"),
+				),
+			},
+			// Step 2: Same config again — should produce no diff
+			{
+				Config:   config,
+				PlanOnly: true,
 			},
 		},
 	})


### PR DESCRIPTION
## Summary

- Add `Default: booldefault.StaticBool(false)` and `Computed: true` to the `blocked` schema attribute so omitting it defaults to `false` instead of null
- Treat nil `Blocked` in API responses as `false` to prevent perpetual diffs between null state and the `false` default
- Add acceptance tests for the add/remove blocked lifecycle and default-false idempotency

Closes #79

## Test plan

- [x] Unit tests pass: `task test:unit -- -run TestClientDevice`
- [ ] Acceptance tests: `TestAccClientDevice_blockedAddRemove` covers the exact issue scenario (create blocked, unblock, remove from config, re-add)
- [ ] Acceptance tests: `TestAccClientDevice_blockedDefaultFalse` verifies omitting `blocked` defaults to `false` with no diff

🤖 Generated with [Claude Code](https://claude.com/claude-code)