### PR TITLE
Fix port_group_id support in firewall policies

### DIFF
--- a/docs/resources/firewall_policy.md
+++ b/docs/resources/firewall_policy.md
@@ -59,6 +59,32 @@ resource "terrifi_firewall_policy" "allow_https" {
 }
 ```
 
+### Block with port group exception
+
+```terraform
+resource "terrifi_firewall_group" "ntp_ports" {
+  name    = "NTP Ports"
+  type    = "port-group"
+  members = ["123"]
+}
+
+resource "terrifi_firewall_policy" "block_except_ntp" {
+  name   = "Block except NTP"
+  action = "BLOCK"
+
+  source {
+    zone_id = terrifi_firewall_zone.iot.id
+  }
+
+  destination {
+    zone_id              = terrifi_firewall_zone.external.id
+    port_matching_type   = "OBJECT"
+    port_group_id        = terrifi_firewall_group.ntp_ports.id
+    match_opposite_ports = true
+  }
+}
+```
+
 ### Block by MAC address
 
 ```terraform
@@ -136,9 +162,9 @@ resource "terrifi_firewall_policy" "weekday_block" {
 - `mac_addresses` (Set of String) — MAC addresses to match. **Note:** Currently only supported in the `source` block. The UniFi v2 API uses different enum types for source vs. destination matching targets, and the destination enum does not include `MAC` (see [#69](https://github.com/alexklibisz/terraform-provider-terrifi/issues/69)).
 - `network_ids` (Set of String) — Network IDs to match.
 - `device_ids` (Set of String) — Client device MAC addresses to match. Use the `mac` attribute from `terrifi_client_device` resources.
-- `port_matching_type` (String) — Port matching type. Valid values: `ANY`, `SPECIFIC`, `LIST`. Default: `ANY`.
+- `port_matching_type` (String) — Port matching type. Valid values: `ANY`, `SPECIFIC`, `OBJECT`. Default: `ANY`. Automatically derived when `port` or `port_group_id` is set.
 - `port` (Number) — Specific port number (when `port_matching_type` is `SPECIFIC`).
-- `port_group_id` (String) — Port group ID (when `port_matching_type` is `LIST`).
+- `port_group_id` (String) — Port group ID (when `port_matching_type` is `OBJECT`).
 - `match_opposite_ports` (Boolean) — Inverts the port matching. When `true` and action is `ALLOW`, all ports _except_ the specified ones are allowed. When `true` and action is `BLOCK`, all ports _except_ the specified ones are blocked.
 - `match_opposite_ips` (Boolean) — Inverts the IP matching. When `true` and action is `ALLOW`, all IPs _except_ the specified ones are allowed. When `true` and action is `BLOCK`, all IPs _except_ the specified ones are blocked.
 

--- a/internal/provider/firewall_policy_api.go
+++ b/internal/provider/firewall_policy_api.go
@@ -368,7 +368,7 @@ func buildEndpointRequest(zoneID, matchingTarget string, ips []string, portMatch
 		ZoneID:             zoneID,
 		MatchingTarget:     matchingTarget,
 		MatchingTargetType: matchingTargetType(matchingTarget),
-		PortMatchingType:   portMatchingType,
+		PortMatchingType:   resolvePortMatchingType(portMatchingType, port, portGroupID),
 		Port:               port,
 		PortGroupID:        portGroupID,
 	}
@@ -392,9 +392,21 @@ func buildEndpointRequest(zoneID, matchingTarget string, ips []string, portMatch
 
 func boolPtr(b bool) *bool { return &b }
 
-// matchingTargetType derives matching_target_type from matching_target.
-// The v2 API requires both fields: matching_target identifies WHAT to match
-// (IP, NETWORK, etc.) and matching_target_type indicates how (ANY vs SPECIFIC).
+// resolvePortMatchingType derives the correct port_matching_type for the API.
+// The v2 API accepts SPECIFIC (when a port number is set), OBJECT (when a port
+// group ID is set), or ANY (no port filter). This function auto-derives the
+// value from what's set, so users don't need to specify port_matching_type
+// explicitly.
+func resolvePortMatchingType(portMatchingType string, port *int64, portGroupID string) string {
+	if portGroupID != "" {
+		return "OBJECT"
+	}
+	if port != nil {
+		return "SPECIFIC"
+	}
+	return portMatchingType
+}
+
 // matchingTargetType derives matching_target_type from matching_target.
 // The v2 API requires this field when matching_target is not ANY. The enum
 // only accepts SPECIFIC or OBJECT (not ANY), so we omit it for ANY targets.

--- a/internal/provider/firewall_policy_resource.go
+++ b/internal/provider/firewall_policy_resource.go
@@ -138,12 +138,12 @@ func (r *firewallPolicyResource) Schema(
 			Optional:            true,
 		},
 		"port_matching_type": schema.StringAttribute{
-			MarkdownDescription: "Port matching type. Valid values: `ANY`, `SPECIFIC`, `LIST`.",
+			MarkdownDescription: "Port matching type. Valid values: `ANY`, `SPECIFIC`, `OBJECT`. Default: `ANY`. Automatically derived when `port` or `port_group_id` is set.",
 			Optional:            true,
 			Computed:            true,
 			Default:             stringdefault.StaticString("ANY"),
 			Validators: []validator.String{
-				stringvalidator.OneOf("ANY", "SPECIFIC", "LIST"),
+				stringvalidator.OneOf("ANY", "SPECIFIC", "OBJECT"),
 			},
 		},
 		"port": schema.Int64Attribute{
@@ -151,7 +151,7 @@ func (r *firewallPolicyResource) Schema(
 			Optional:            true,
 		},
 		"port_group_id": schema.StringAttribute{
-			MarkdownDescription: "Port group ID to match (when `port_matching_type` is `LIST`).",
+			MarkdownDescription: "Port group ID to match (when `port_matching_type` is `OBJECT`).",
 			Optional:            true,
 		},
 		"match_opposite_ports": schema.BoolAttribute{

--- a/internal/provider/firewall_policy_resource_test.go
+++ b/internal/provider/firewall_policy_resource_test.go
@@ -526,6 +526,56 @@ func TestFirewallPolicyModelToAPI(t *testing.T) {
 		assert.False(t, policy.Destination.MatchOppositePorts)
 		assert.True(t, policy.Destination.MatchOppositeIPs)
 	})
+
+	t.Run("with port group ID and match opposite ports", func(t *testing.T) {
+		srcObj := types.ObjectValueMust(endpointAttrTypes, map[string]attr.Value{
+			"zone_id":              types.StringValue("zone-src"),
+			"ips":                  types.SetNull(types.StringType),
+			"mac_addresses":        types.SetNull(types.StringType),
+			"network_ids":          types.SetNull(types.StringType),
+			"device_ids":           types.SetNull(types.StringType),
+			"port_matching_type":   types.StringValue("ANY"),
+			"port":                 types.Int64Null(),
+			"port_group_id":        types.StringNull(),
+			"match_opposite_ports": types.BoolNull(),
+			"match_opposite_ips":   types.BoolNull(),
+		})
+		dstObj := types.ObjectValueMust(endpointAttrTypes, map[string]attr.Value{
+			"zone_id":              types.StringValue("zone-dst"),
+			"ips":                  types.SetNull(types.StringType),
+			"mac_addresses":        types.SetNull(types.StringType),
+			"network_ids":          types.SetNull(types.StringType),
+			"device_ids":           types.SetNull(types.StringType),
+			"port_matching_type":   types.StringValue("ANY"),
+			"port":                 types.Int64Null(),
+			"port_group_id":        types.StringValue("pg-001"),
+			"match_opposite_ports": types.BoolValue(true),
+			"match_opposite_ips":   types.BoolNull(),
+		})
+
+		model := &firewallPolicyResourceModel{
+			Name:                types.StringValue("Port Group Rule"),
+			Action:              types.StringValue("BLOCK"),
+			Enabled:             types.BoolValue(true),
+			IPVersion:           types.StringValue("BOTH"),
+			Protocol:            types.StringValue("all"),
+			ConnectionStateType: types.StringValue("ALL"),
+			ConnectionStates:    types.SetNull(types.StringType),
+			Description:         types.StringNull(),
+			MatchIPSec:          types.BoolNull(),
+			Logging:             types.BoolNull(),
+			CreateAllowRespond:  types.BoolNull(),
+			Index:               types.Int64Null(),
+			Source:              srcObj,
+			Destination:         dstObj,
+			Schedule:            types.ObjectNull(scheduleAttrTypes),
+		}
+
+		policy := r.modelToAPI(ctx, model)
+
+		assert.Equal(t, "pg-001", policy.Destination.PortGroupID)
+		assert.True(t, policy.Destination.MatchOppositePorts)
+	})
 }
 
 func TestFirewallPolicyAPIToModel(t *testing.T) {
@@ -901,6 +951,35 @@ func TestFirewallPolicyAPIToModel(t *testing.T) {
 		assert.True(t, dstModel.MatchOppositePorts.IsNull())
 		assert.True(t, dstModel.MatchOppositeIPs.IsNull())
 	})
+
+	t.Run("port_group_id and OBJECT port_matching_type round-trip", func(t *testing.T) {
+		policy := &unifi.FirewallPolicy{
+			ID:     "pol-013",
+			Name:   "Port Group Rule",
+			Action: "BLOCK",
+			Source: &unifi.FirewallPolicySource{
+				ZoneID:         "zone-src",
+				MatchingTarget: "ANY",
+			},
+			Destination: &unifi.FirewallPolicyDestination{
+				ZoneID:             "zone-dst",
+				MatchingTarget:     "ANY",
+				PortMatchingType:   "OBJECT",
+				PortGroupID:        "pg-001",
+				MatchOppositePorts: true,
+			},
+		}
+
+		var model firewallPolicyResourceModel
+		r.apiToModel(policy, &model, "default")
+
+		var dstModel firewallPolicyEndpointModel
+		model.Destination.As(context.Background(), &dstModel, basetypes.ObjectAsOptions{})
+		assert.Equal(t, "OBJECT", dstModel.PortMatchingType.ValueString())
+		assert.Equal(t, "pg-001", dstModel.PortGroupID.ValueString())
+		assert.True(t, dstModel.MatchOppositePorts.ValueBool())
+		assert.True(t, dstModel.Port.IsNull())
+	})
 }
 
 func TestFirewallPolicyApplyPlanToState(t *testing.T) {
@@ -989,6 +1068,50 @@ func TestBuildEndpointRequest(t *testing.T) {
 		ep := buildEndpointRequest("zone1", "ANY", nil, "ANY", nil, "", false, false)
 		assert.Nil(t, ep.MatchOppositePorts)
 		assert.Nil(t, ep.MatchOppositeIPs)
+	})
+
+	t.Run("port_group_id sets port_matching_type to OBJECT", func(t *testing.T) {
+		ep := buildEndpointRequest("zone1", "ANY", nil, "ANY", nil, "pg-001", true, false)
+		assert.Equal(t, "OBJECT", ep.PortMatchingType)
+		assert.Equal(t, "pg-001", ep.PortGroupID)
+		assert.NotNil(t, ep.MatchOppositePorts)
+		assert.True(t, *ep.MatchOppositePorts)
+	})
+
+	t.Run("port sets port_matching_type to SPECIFIC", func(t *testing.T) {
+		port := int64(443)
+		ep := buildEndpointRequest("zone1", "ANY", nil, "ANY", &port, "", false, false)
+		assert.Equal(t, "SPECIFIC", ep.PortMatchingType)
+		assert.Equal(t, int64(443), *ep.Port)
+	})
+
+	t.Run("port_matching_type preserved when no port or port_group_id", func(t *testing.T) {
+		ep := buildEndpointRequest("zone1", "ANY", nil, "ANY", nil, "", false, false)
+		assert.Equal(t, "ANY", ep.PortMatchingType)
+	})
+}
+
+func TestResolvePortMatchingType(t *testing.T) {
+	t.Run("port_group_id takes precedence", func(t *testing.T) {
+		port := int64(443)
+		result := resolvePortMatchingType("ANY", &port, "pg-001")
+		assert.Equal(t, "OBJECT", result)
+	})
+
+	t.Run("port sets SPECIFIC", func(t *testing.T) {
+		port := int64(80)
+		result := resolvePortMatchingType("ANY", &port, "")
+		assert.Equal(t, "SPECIFIC", result)
+	})
+
+	t.Run("neither falls through", func(t *testing.T) {
+		result := resolvePortMatchingType("ANY", nil, "")
+		assert.Equal(t, "ANY", result)
+	})
+
+	t.Run("explicit OBJECT preserved", func(t *testing.T) {
+		result := resolvePortMatchingType("OBJECT", nil, "pg-001")
+		assert.Equal(t, "OBJECT", result)
 	})
 }
 
@@ -1933,6 +2056,335 @@ resource "terrifi_firewall_policy" "test" {
 				Check: resource.ComposeTestCheckFunc(
 					resource.TestCheckResourceAttr("terrifi_firewall_policy.test", "destination.match_opposite_ports", "true"),
 				),
+			},
+		},
+	})
+}
+
+func TestAccFirewallPolicy_portGroupID(t *testing.T) {
+	zone1Name := fmt.Sprintf("tfacc-pol-pg-z1-%s", randomSuffix())
+	zone2Name := fmt.Sprintf("tfacc-pol-pg-z2-%s", randomSuffix())
+	groupName := fmt.Sprintf("tfacc-pol-pg-grp-%s", randomSuffix())
+	policyName := fmt.Sprintf("tfacc-pol-pg-%s", randomSuffix())
+
+	zonesConfig := testAccFirewallPolicyZonesConfig(zone1Name, zone2Name)
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:                 func() { preCheck(t); requireHardware(t) },
+		ProtoV6ProviderFactories: testAccProtoV6ProviderFactories,
+		Steps: []resource.TestStep{
+			// Step 1: Create policy with port_group_id on destination.
+			{
+				Config: zonesConfig + fmt.Sprintf(`
+resource "terrifi_firewall_group" "test_ports" {
+  name    = %q
+  type    = "port-group"
+  members = ["123"]
+}
+
+resource "terrifi_firewall_policy" "test" {
+  name     = %q
+  action   = "BLOCK"
+  protocol = "udp"
+
+  source {
+    zone_id = terrifi_firewall_zone.zone1.id
+  }
+
+  destination {
+    zone_id            = terrifi_firewall_zone.zone2.id
+    port_matching_type = "OBJECT"
+    port_group_id      = terrifi_firewall_group.test_ports.id
+  }
+}
+`, groupName, policyName),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttrSet("terrifi_firewall_policy.test", "destination.port_group_id"),
+					resource.TestCheckResourceAttr("terrifi_firewall_policy.test", "destination.port_matching_type", "OBJECT"),
+				),
+			},
+			// Step 2: No drift on re-apply.
+			{
+				Config: zonesConfig + fmt.Sprintf(`
+resource "terrifi_firewall_group" "test_ports" {
+  name    = %q
+  type    = "port-group"
+  members = ["123"]
+}
+
+resource "terrifi_firewall_policy" "test" {
+  name     = %q
+  action   = "BLOCK"
+  protocol = "udp"
+
+  source {
+    zone_id = terrifi_firewall_zone.zone1.id
+  }
+
+  destination {
+    zone_id            = terrifi_firewall_zone.zone2.id
+    port_matching_type = "OBJECT"
+    port_group_id      = terrifi_firewall_group.test_ports.id
+  }
+}
+`, groupName, policyName),
+				PlanOnly: true,
+			},
+		},
+	})
+}
+
+func TestAccFirewallPolicy_portGroupIDWithMatchOpposite(t *testing.T) {
+	zone1Name := fmt.Sprintf("tfacc-pol-pgmo-z1-%s", randomSuffix())
+	zone2Name := fmt.Sprintf("tfacc-pol-pgmo-z2-%s", randomSuffix())
+	groupName := fmt.Sprintf("tfacc-pol-pgmo-grp-%s", randomSuffix())
+	policyName := fmt.Sprintf("tfacc-pol-pgmo-%s", randomSuffix())
+
+	zonesConfig := testAccFirewallPolicyZonesConfig(zone1Name, zone2Name)
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:                 func() { preCheck(t); requireHardware(t) },
+		ProtoV6ProviderFactories: testAccProtoV6ProviderFactories,
+		Steps: []resource.TestStep{
+			// Step 1: Create with port_group_id + match_opposite_ports (the issue #84 scenario).
+			{
+				Config: zonesConfig + fmt.Sprintf(`
+resource "terrifi_firewall_group" "test_ports" {
+  name    = %q
+  type    = "port-group"
+  members = ["123"]
+}
+
+resource "terrifi_firewall_policy" "test" {
+  name     = %q
+  action   = "BLOCK"
+  protocol = "udp"
+
+  source {
+    zone_id = terrifi_firewall_zone.zone1.id
+  }
+
+  destination {
+    zone_id              = terrifi_firewall_zone.zone2.id
+    port_matching_type   = "OBJECT"
+    port_group_id        = terrifi_firewall_group.test_ports.id
+    match_opposite_ports = true
+  }
+}
+`, groupName, policyName),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttrSet("terrifi_firewall_policy.test", "destination.port_group_id"),
+					resource.TestCheckResourceAttr("terrifi_firewall_policy.test", "destination.port_matching_type", "OBJECT"),
+					resource.TestCheckResourceAttr("terrifi_firewall_policy.test", "destination.match_opposite_ports", "true"),
+				),
+			},
+			// Step 2: No drift on re-apply.
+			{
+				Config: zonesConfig + fmt.Sprintf(`
+resource "terrifi_firewall_group" "test_ports" {
+  name    = %q
+  type    = "port-group"
+  members = ["123"]
+}
+
+resource "terrifi_firewall_policy" "test" {
+  name     = %q
+  action   = "BLOCK"
+  protocol = "udp"
+
+  source {
+    zone_id = terrifi_firewall_zone.zone1.id
+  }
+
+  destination {
+    zone_id              = terrifi_firewall_zone.zone2.id
+    port_matching_type   = "OBJECT"
+    port_group_id        = terrifi_firewall_group.test_ports.id
+    match_opposite_ports = true
+  }
+}
+`, groupName, policyName),
+				PlanOnly: true,
+			},
+		},
+	})
+}
+
+func TestAccFirewallPolicy_portGroupIDUpdate(t *testing.T) {
+	zone1Name := fmt.Sprintf("tfacc-pol-pgu-z1-%s", randomSuffix())
+	zone2Name := fmt.Sprintf("tfacc-pol-pgu-z2-%s", randomSuffix())
+	groupName := fmt.Sprintf("tfacc-pol-pgu-grp-%s", randomSuffix())
+	policyName := fmt.Sprintf("tfacc-pol-pgu-%s", randomSuffix())
+
+	zonesConfig := testAccFirewallPolicyZonesConfig(zone1Name, zone2Name)
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:                 func() { preCheck(t); requireHardware(t) },
+		ProtoV6ProviderFactories: testAccProtoV6ProviderFactories,
+		Steps: []resource.TestStep{
+			// Step 1: Create with specific port.
+			{
+				Config: zonesConfig + fmt.Sprintf(`
+resource "terrifi_firewall_group" "test_ports" {
+  name    = %q
+  type    = "port-group"
+  members = ["123"]
+}
+
+resource "terrifi_firewall_policy" "test" {
+  name     = %q
+  action   = "BLOCK"
+  protocol = "udp"
+
+  source {
+    zone_id = terrifi_firewall_zone.zone1.id
+  }
+
+  destination {
+    zone_id            = terrifi_firewall_zone.zone2.id
+    port_matching_type = "SPECIFIC"
+    port               = 123
+  }
+}
+`, groupName, policyName),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr("terrifi_firewall_policy.test", "destination.port", "123"),
+					resource.TestCheckResourceAttr("terrifi_firewall_policy.test", "destination.port_matching_type", "SPECIFIC"),
+				),
+			},
+			// Step 2: Update to use port group instead.
+			{
+				Config: zonesConfig + fmt.Sprintf(`
+resource "terrifi_firewall_group" "test_ports" {
+  name    = %q
+  type    = "port-group"
+  members = ["123"]
+}
+
+resource "terrifi_firewall_policy" "test" {
+  name     = %q
+  action   = "BLOCK"
+  protocol = "udp"
+
+  source {
+    zone_id = terrifi_firewall_zone.zone1.id
+  }
+
+  destination {
+    zone_id              = terrifi_firewall_zone.zone2.id
+    port_matching_type   = "OBJECT"
+    port_group_id        = terrifi_firewall_group.test_ports.id
+    match_opposite_ports = true
+  }
+}
+`, groupName, policyName),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttrSet("terrifi_firewall_policy.test", "destination.port_group_id"),
+					resource.TestCheckResourceAttr("terrifi_firewall_policy.test", "destination.port_matching_type", "OBJECT"),
+					resource.TestCheckResourceAttr("terrifi_firewall_policy.test", "destination.match_opposite_ports", "true"),
+				),
+			},
+			// Step 3: No drift on re-apply.
+			{
+				Config: zonesConfig + fmt.Sprintf(`
+resource "terrifi_firewall_group" "test_ports" {
+  name    = %q
+  type    = "port-group"
+  members = ["123"]
+}
+
+resource "terrifi_firewall_policy" "test" {
+  name     = %q
+  action   = "BLOCK"
+  protocol = "udp"
+
+  source {
+    zone_id = terrifi_firewall_zone.zone1.id
+  }
+
+  destination {
+    zone_id              = terrifi_firewall_zone.zone2.id
+    port_matching_type   = "OBJECT"
+    port_group_id        = terrifi_firewall_group.test_ports.id
+    match_opposite_ports = true
+  }
+}
+`, groupName, policyName),
+				PlanOnly: true,
+			},
+		},
+	})
+}
+
+func TestAccFirewallPolicy_portGroupIDOnSource(t *testing.T) {
+	zone1Name := fmt.Sprintf("tfacc-pol-pgs-z1-%s", randomSuffix())
+	zone2Name := fmt.Sprintf("tfacc-pol-pgs-z2-%s", randomSuffix())
+	groupName := fmt.Sprintf("tfacc-pol-pgs-grp-%s", randomSuffix())
+	policyName := fmt.Sprintf("tfacc-pol-pgs-%s", randomSuffix())
+
+	zonesConfig := testAccFirewallPolicyZonesConfig(zone1Name, zone2Name)
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:                 func() { preCheck(t); requireHardware(t) },
+		ProtoV6ProviderFactories: testAccProtoV6ProviderFactories,
+		Steps: []resource.TestStep{
+			{
+				Config: zonesConfig + fmt.Sprintf(`
+resource "terrifi_firewall_group" "test_ports" {
+  name    = %q
+  type    = "port-group"
+  members = ["80", "443"]
+}
+
+resource "terrifi_firewall_policy" "test" {
+  name     = %q
+  action   = "ALLOW"
+  protocol = "tcp"
+
+  source {
+    zone_id              = terrifi_firewall_zone.zone1.id
+    port_matching_type   = "OBJECT"
+    port_group_id        = terrifi_firewall_group.test_ports.id
+    match_opposite_ports = true
+  }
+
+  destination {
+    zone_id = terrifi_firewall_zone.zone2.id
+  }
+}
+`, groupName, policyName),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttrSet("terrifi_firewall_policy.test", "source.port_group_id"),
+					resource.TestCheckResourceAttr("terrifi_firewall_policy.test", "source.port_matching_type", "OBJECT"),
+					resource.TestCheckResourceAttr("terrifi_firewall_policy.test", "source.match_opposite_ports", "true"),
+				),
+			},
+			{
+				Config: zonesConfig + fmt.Sprintf(`
+resource "terrifi_firewall_group" "test_ports" {
+  name    = %q
+  type    = "port-group"
+  members = ["80", "443"]
+}
+
+resource "terrifi_firewall_policy" "test" {
+  name     = %q
+  action   = "ALLOW"
+  protocol = "tcp"
+
+  source {
+    zone_id              = terrifi_firewall_zone.zone1.id
+    port_matching_type   = "OBJECT"
+    port_group_id        = terrifi_firewall_group.test_ports.id
+    match_opposite_ports = true
+  }
+
+  destination {
+    zone_id = terrifi_firewall_zone.zone2.id
+  }
+}
+`, groupName, policyName),
+				PlanOnly: true,
 			},
 		},
 	})


### PR DESCRIPTION
## Summary

Fixes #84.

- The `port_matching_type` schema validator accepted `LIST`, but the UniFi v2 API only accepts `ANY`, `SPECIFIC`, or `OBJECT`. When `port_group_id` is set, the API requires `port_matching_type=OBJECT`. This caused 400 errors when users tried to use `port_group_id` with `match_opposite_ports`.
- Replaced `LIST` with `OBJECT` in the schema validator and added `resolvePortMatchingType()` as a safety net that auto-derives the correct value from the `port`/`port_group_id` fields.
- Added unit tests, 4 new hardware acceptance tests (all passing), and updated docs with a port group example.

### Usage

```hcl
resource "terrifi_firewall_policy" "block_except_ntp" {
  name   = "Block except NTP"
  action = "BLOCK"

  source {
    zone_id = terrifi_firewall_zone.iot.id
  }

  destination {
    zone_id              = terrifi_firewall_zone.external.id
    port_matching_type   = "OBJECT"
    port_group_id        = terrifi_firewall_group.ntp_ports.id
    match_opposite_ports = true
  }
}
```

## Test plan

- [x] All existing unit tests pass
- [x] All existing hardware acceptance tests pass (113 tests)
- [x] New unit tests: `TestResolvePortMatchingType`, port_group_id cases in `TestBuildEndpointRequest`, `TestFirewallPolicyModelToAPI`, `TestFirewallPolicyAPIToModel`
- [x] New acceptance tests: `TestAccFirewallPolicy_portGroupID`, `TestAccFirewallPolicy_portGroupIDWithMatchOpposite`, `TestAccFirewallPolicy_portGroupIDUpdate`, `TestAccFirewallPolicy_portGroupIDOnSource`

🤖 Generated with [Claude Code](https://claude.com/claude-code)