### PR TITLE
Validate policy zones before reordering to prevent cryptic 404

### DIFF
--- a/internal/provider/firewall_policy_order_resource.go
+++ b/internal/provider/firewall_policy_order_resource.go
@@ -141,6 +141,11 @@ func (r *firewallPolicyOrderResource) Create(
 		return
 	}
 
+	r.validatePolicyZones(ctx, site, sourceZoneID, destZoneID, policyIDs, &resp.Diagnostics)
+	if resp.Diagnostics.HasError() {
+		return
+	}
+
 	_, err := r.client.ReorderFirewallPolicies(ctx, site, sourceZoneID, destZoneID, policyIDs)
 	if err != nil {
 		resp.Diagnostics.AddError("Error Reordering Firewall Policies", err.Error())
@@ -199,6 +204,11 @@ func (r *firewallPolicyOrderResource) Update(
 		return
 	}
 
+	r.validatePolicyZones(ctx, site, sourceZoneID, destZoneID, policyIDs, &resp.Diagnostics)
+	if resp.Diagnostics.HasError() {
+		return
+	}
+
 	_, err := r.client.ReorderFirewallPolicies(ctx, site, sourceZoneID, destZoneID, policyIDs)
 	if err != nil {
 		resp.Diagnostics.AddError("Error Reordering Firewall Policies", err.Error())
@@ -251,6 +261,66 @@ func (r *firewallPolicyOrderResource) ImportState(
 			"Invalid Import ID",
 			fmt.Sprintf("Expected format: source_zone_id:destination_zone_id or site:source_zone_id:destination_zone_id, got: %s", req.ID),
 		)
+	}
+}
+
+// validatePolicyZones checks that each policy in policyIDs belongs to the
+// specified zone pair. The UniFi batch-reorder API returns a cryptic 404
+// "Firewall Policy Not Found" when a policy's zones don't match, so this
+// provides a clear error message instead.
+func (r *firewallPolicyOrderResource) validatePolicyZones(
+	ctx context.Context,
+	site, sourceZoneID, destZoneID string,
+	policyIDs []string,
+	diags *diag.Diagnostics,
+) {
+	policies, err := r.client.ListFirewallPolicies(ctx, site)
+	if err != nil {
+		diags.AddError(
+			"Error Validating Firewall Policies",
+			fmt.Sprintf("Could not list firewall policies to validate zone membership: %s", err.Error()),
+		)
+		return
+	}
+
+	// Build a lookup by policy ID.
+	type policyInfo struct {
+		name         string
+		sourceZoneID string
+		destZoneID   string
+	}
+	byID := make(map[string]policyInfo, len(policies))
+	for _, p := range policies {
+		info := policyInfo{name: p.Name}
+		if p.Source != nil {
+			info.sourceZoneID = p.Source.ZoneID
+		}
+		if p.Destination != nil {
+			info.destZoneID = p.Destination.ZoneID
+		}
+		byID[p.ID] = info
+	}
+
+	for _, id := range policyIDs {
+		p, ok := byID[id]
+		if !ok {
+			diags.AddError(
+				"Firewall Policy Not Found",
+				fmt.Sprintf("Policy %q does not exist on the controller.", id),
+			)
+			continue
+		}
+		if p.sourceZoneID != sourceZoneID || p.destZoneID != destZoneID {
+			diags.AddError(
+				"Firewall Policy Zone Mismatch",
+				fmt.Sprintf(
+					"Policy %q (%s) has source_zone_id=%q and destination_zone_id=%q, "+
+						"but this terrifi_firewall_policy_order expects source_zone_id=%q and destination_zone_id=%q. "+
+						"Each policy's zones must match the ordering resource's zones.",
+					id, p.name, p.sourceZoneID, p.destZoneID, sourceZoneID, destZoneID,
+				),
+			)
+		}
 	}
 }
 

--- a/internal/provider/firewall_policy_order_resource_test.go
+++ b/internal/provider/firewall_policy_order_resource_test.go
@@ -2,6 +2,7 @@ package provider
 
 import (
 	"fmt"
+	"regexp"
 	"testing"
 
 	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
@@ -290,6 +291,61 @@ resource "terrifi_firewall_policy_order" "test" {
 						"terrifi_firewall_zone.zone3", "id",
 					),
 				),
+			},
+		},
+	})
+}
+
+func TestAccFirewallPolicyOrder_zoneMismatch(t *testing.T) {
+	zone1Name := fmt.Sprintf("tfacc-ord-zm-z1-%s", randomSuffix())
+	zone2Name := fmt.Sprintf("tfacc-ord-zm-z2-%s", randomSuffix())
+	zone3Name := fmt.Sprintf("tfacc-ord-zm-z3-%s", randomSuffix())
+	polName := fmt.Sprintf("tfacc-ord-zm-p1-%s", randomSuffix())
+
+	// Policy goes zone1 -> zone2, but order resource specifies zone1 -> zone3.
+	config := fmt.Sprintf(`
+resource "terrifi_firewall_zone" "zone1" {
+  name = %q
+}
+
+resource "terrifi_firewall_zone" "zone2" {
+  name = %q
+}
+
+resource "terrifi_firewall_zone" "zone3" {
+  name = %q
+}
+
+resource "terrifi_firewall_policy" "pol1" {
+  name   = %q
+  action = "BLOCK"
+
+  source {
+    zone_id = terrifi_firewall_zone.zone1.id
+  }
+
+  destination {
+    zone_id = terrifi_firewall_zone.zone2.id
+  }
+}
+
+resource "terrifi_firewall_policy_order" "test" {
+  source_zone_id      = terrifi_firewall_zone.zone1.id
+  destination_zone_id = terrifi_firewall_zone.zone3.id
+
+  policy_ids = [
+    terrifi_firewall_policy.pol1.id,
+  ]
+}
+`, zone1Name, zone2Name, zone3Name, polName)
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:                 func() { preCheck(t); requireHardware(t) },
+		ProtoV6ProviderFactories: testAccProtoV6ProviderFactories,
+		Steps: []resource.TestStep{
+			{
+				Config:      config,
+				ExpectError: regexp.MustCompile(`Firewall Policy Zone Mismatch`),
 			},
 		},
 	})


### PR DESCRIPTION
## Summary
- Fixes #85
- The UniFi batch-reorder API returns a cryptic 404 "Firewall Policy Not Found" when a policy's source/destination zones don't match the zone pair in the reorder request
- Adds pre-flight validation in `Create` and `Update` that lists all policies and checks each referenced policy's zones match, returning a clear `Firewall Policy Zone Mismatch` error instead
- Adds `TestAccFirewallPolicyOrder_zoneMismatch` acceptance test

## Test plan
- [x] `TestAccFirewallPolicyOrder_zoneMismatch` — verifies zone mismatch produces a clear error
- [x] All existing `TestAccFirewallPolicyOrder_*` tests still pass
- [x] Full hardware acceptance test suite passes (113 tests)

🤖 Generated with [Claude Code](https://claude.com/claude-code)