### PR TITLE
Add list-device-types CLI command

### DIFF
--- a/cmd/terrifi/list_device_types.go
+++ b/cmd/terrifi/list_device_types.go
@@ -1,0 +1,322 @@
+package main
+
+import (
+	"context"
+	"encoding/csv"
+	"fmt"
+	"html"
+	"os"
+	"sort"
+	"strconv"
+
+	"github.com/alexklibisz/terrifi/internal/provider"
+	"github.com/spf13/cobra"
+)
+
+func listDeviceTypesCmd() *cobra.Command {
+	cmd := &cobra.Command{
+		Use:   "list-device-types",
+		Short: "List available device types (fingerprint IDs) from the UniFi controller",
+		Long: "Queries the UniFi controller's fingerprint database and outputs all known " +
+			"device types with their IDs as CSV. These IDs can be used as dev_id_override " +
+			"values to set custom icons on client devices.\n\n" +
+			"Use --html to generate a browsable HTML page with icons, fuzzy search, " +
+			"and filterable type/vendor dropdowns.\n\n" +
+			"Requires UNIFI_* environment variables to be configured.",
+		Args: cobra.NoArgs,
+		RunE: runListDeviceTypes,
+	}
+	cmd.Flags().Bool("html", false, "Generate a self-contained HTML page (unifi-device-types.html) with icons and fuzzy search")
+	return cmd
+}
+
+func runListDeviceTypes(cmd *cobra.Command, args []string) error {
+	ctx := context.Background()
+
+	cfg := provider.ClientConfigFromEnv()
+	client, err := provider.NewClient(ctx, cfg)
+	if err != nil {
+		return fmt.Errorf("connecting to UniFi controller: %w", err)
+	}
+
+	devices, err := client.ListFingerprintDevices(ctx, 0)
+	if err != nil {
+		return fmt.Errorf("listing device types: %w", err)
+	}
+
+	if len(devices) == 0 {
+		fmt.Fprintln(os.Stderr, "No device types found.")
+		return nil
+	}
+
+	fmt.Fprintf(os.Stderr, "Found %d device types.\n", len(devices))
+
+	htmlFlag, _ := cmd.Flags().GetBool("html")
+	if htmlFlag {
+		return writeDeviceTypesHTML(devices)
+	}
+
+	return writeDeviceTypesCSV(devices)
+}
+
+func iconURL(id int64) string {
+	return fmt.Sprintf("https://static.ui.com/fingerprint/0/%d_257x257.png", id)
+}
+
+func writeDeviceTypesCSV(devices []provider.FingerprintDevice) error {
+	w := csv.NewWriter(os.Stdout)
+	defer w.Flush()
+
+	if err := w.Write([]string{"id", "name", "dev_type", "family", "vendor", "icon_url"}); err != nil {
+		return err
+	}
+
+	for _, d := range devices {
+		record := []string{
+			strconv.FormatInt(d.ID, 10),
+			d.Name,
+			d.DevType,
+			d.Family,
+			d.Vendor,
+			iconURL(d.ID),
+		}
+		if err := w.Write(record); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+func writeDeviceTypesHTML(devices []provider.FingerprintDevice) error {
+	// Collect unique types and vendors for the filter dropdowns.
+	typeSet := map[string]bool{}
+	vendorSet := map[string]bool{}
+	for _, d := range devices {
+		if d.DevType != "" {
+			typeSet[d.DevType] = true
+		}
+		if d.Vendor != "" {
+			vendorSet[d.Vendor] = true
+		}
+	}
+	types := sortedKeys(typeSet)
+	vendors := sortedKeys(vendorSet)
+
+	const outputFile = "unifi-device-types.html"
+	f, err := os.Create(outputFile)
+	if err != nil {
+		return fmt.Errorf("creating %s: %w", outputFile, err)
+	}
+	defer f.Close()
+
+	fmt.Fprint(f, `<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="utf-8">
+<meta name="viewport" content="width=device-width, initial-scale=1">
+<title>UniFi Device Types</title>
+<script src="https://cdn.jsdelivr.net/npm/fuse.js@7.0.0/dist/fuse.min.js"></script>
+<style>
+  * { box-sizing: border-box; margin: 0; padding: 0; }
+  body { font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, sans-serif; background: #f5f5f5; color: #333; }
+  .header { background: #1a1a2e; color: #fff; padding: 24px; position: sticky; top: 0; z-index: 10; }
+  .header h1 { font-size: 20px; margin-bottom: 12px; }
+  .controls { display: flex; flex-wrap: wrap; gap: 10px; align-items: center; }
+  .controls input {
+    flex: 1; min-width: 200px; max-width: 500px; padding: 10px 14px; font-size: 16px;
+    border: none; border-radius: 6px; outline: none;
+  }
+  .controls select {
+    padding: 10px 14px; font-size: 14px; border: none; border-radius: 6px;
+    background: #fff; color: #333; cursor: pointer; outline: none;
+  }
+  .header .stats { font-size: 13px; color: #aaa; margin-top: 8px; }
+  table { width: 100%; border-collapse: collapse; background: #fff; }
+  th { background: #e8e8e8; position: sticky; top: 130px; text-align: left; padding: 10px 14px; font-size: 13px; }
+  td { padding: 8px 14px; border-bottom: 1px solid #eee; vertical-align: middle; }
+  tr.hidden { display: none; }
+  .icon { width: 48px; height: 48px; object-fit: contain; }
+  .id { font-family: monospace; font-size: 14px; color: #666; }
+  .name { font-weight: 500; }
+  .meta { font-size: 12px; color: #888; }
+</style>
+</head>
+<body>
+<div class="header">
+  <h1>UniFi Device Types</h1>
+  <div class="controls">
+    <input type="text" id="search" placeholder="Fuzzy search by name..." autofocus>
+    <select id="filter-type"><option value="">All Types</option>
+`)
+
+	for _, t := range types {
+		fmt.Fprintf(f, "    <option value=\"%s\">%s</option>\n", html.EscapeString(t), html.EscapeString(t))
+	}
+
+	fmt.Fprint(f, `    </select>
+    <select id="filter-vendor"><option value="">All Vendors</option>
+`)
+
+	for _, v := range vendors {
+		fmt.Fprintf(f, "    <option value=\"%s\">%s</option>\n", html.EscapeString(v), html.EscapeString(v))
+	}
+
+	fmt.Fprint(f, `    </select>
+  </div>
+  <div class="stats" id="stats"></div>
+</div>
+<table>
+<thead><tr><th>Icon</th><th>ID</th><th>Name</th><th>Type / Vendor</th></tr></thead>
+<tbody id="tbody">
+`)
+
+	for _, d := range devices {
+		fmt.Fprintf(f, `<tr data-id="%d" data-type="%s" data-vendor="%s"><td><img class="icon" src="%s" alt="%s" loading="lazy"></td><td class="id">%d</td><td class="name">%s</td><td class="meta">%s · %s</td></tr>
+`,
+			d.ID,
+			html.EscapeString(d.DevType),
+			html.EscapeString(d.Vendor),
+			iconURL(d.ID),
+			html.EscapeString(d.Name),
+			d.ID,
+			html.EscapeString(d.Name),
+			html.EscapeString(d.DevType),
+			html.EscapeString(d.Vendor),
+		)
+	}
+
+	fmt.Fprint(f, `</tbody>
+</table>
+<script>
+const tbody = document.getElementById('tbody');
+const rows = Array.from(tbody.querySelectorAll('tr'));
+const totalCount = rows.length;
+const rowById = {};
+rows.forEach(r => rowById[r.dataset.id] = r);
+
+const items = rows.map(row => ({
+  id: row.dataset.id,
+  name: row.querySelector('.name')?.textContent || '',
+  meta: row.querySelector('.meta')?.textContent || '',
+}));
+
+const fuse = new Fuse(items, {
+  keys: ['name', 'meta'],
+  threshold: 0.3,
+  ignoreLocation: true,
+});
+
+const searchInput = document.getElementById('search');
+const filterType = document.getElementById('filter-type');
+const filterVendor = document.getElementById('filter-vendor');
+const stats = document.getElementById('stats');
+
+function updateSelectOptions(select, attr, allLabel, visibleRows) {
+  const current = select.value;
+  const available = new Set();
+  visibleRows.forEach(r => {
+    const v = r.dataset[attr];
+    if (v) available.add(v);
+  });
+  const sorted = Array.from(available).sort();
+
+  select.innerHTML = '';
+  const allOpt = document.createElement('option');
+  allOpt.value = '';
+  allOpt.textContent = allLabel + ' (' + sorted.length + ')';
+  select.appendChild(allOpt);
+
+  for (const val of sorted) {
+    const opt = document.createElement('option');
+    opt.value = val;
+    opt.textContent = val;
+    if (val === current) opt.selected = true;
+    select.appendChild(opt);
+  }
+
+  if (current && !available.has(current)) {
+    select.value = '';
+  }
+}
+
+function applyFilters() {
+  const query = searchInput.value.trim();
+  const selectedType = filterType.value;
+  const selectedVendor = filterVendor.value;
+
+  let orderedIds;
+  if (query) {
+    orderedIds = fuse.search(query).map(r => r.item.id);
+  } else {
+    orderedIds = rows.map(r => r.dataset.id);
+  }
+
+  const matchIdSet = query ? new Set(orderedIds) : null;
+
+  let shown = 0;
+  rows.forEach(r => {
+    const passSearch = !matchIdSet || matchIdSet.has(r.dataset.id);
+    const passType = !selectedType || r.dataset.type === selectedType;
+    const passVendor = !selectedVendor || r.dataset.vendor === selectedVendor;
+
+    if (passSearch && passType && passVendor) {
+      r.classList.remove('hidden');
+      shown++;
+    } else {
+      r.classList.add('hidden');
+    }
+  });
+
+  if (query) {
+    for (const id of orderedIds) {
+      const row = rowById[id];
+      if (!row.classList.contains('hidden')) {
+        tbody.appendChild(row);
+      }
+    }
+  } else {
+    rows.forEach(r => tbody.appendChild(r));
+  }
+
+  const rowsForType = rows.filter(r => {
+    const passSearch = !matchIdSet || matchIdSet.has(r.dataset.id);
+    const passVendor = !selectedVendor || r.dataset.vendor === selectedVendor;
+    return passSearch && passVendor;
+  });
+  const rowsForVendor = rows.filter(r => {
+    const passSearch = !matchIdSet || matchIdSet.has(r.dataset.id);
+    const passType = !selectedType || r.dataset.type === selectedType;
+    return passSearch && passType;
+  });
+
+  updateSelectOptions(filterType, 'type', 'All Types', rowsForType);
+  updateSelectOptions(filterVendor, 'vendor', 'All Vendors', rowsForVendor);
+
+  if (!query && !selectedType && !selectedVendor) {
+    stats.textContent = totalCount + ' device types';
+  } else {
+    stats.textContent = shown + ' / ' + totalCount + ' device types';
+  }
+}
+
+searchInput.addEventListener('input', applyFilters);
+filterType.addEventListener('change', applyFilters);
+filterVendor.addEventListener('change', applyFilters);
+applyFilters();
+</script>
+</body>
+</html>
+`)
+
+	fmt.Fprintf(os.Stderr, "Wrote %s\n", outputFile)
+	return nil
+}
+
+func sortedKeys(m map[string]bool) []string {
+	keys := make([]string, 0, len(m))
+	for k := range m {
+		keys = append(keys, k)
+	}
+	sort.Strings(keys)
+	return keys
+}

--- a/cmd/terrifi/main.go
+++ b/cmd/terrifi/main.go
@@ -33,6 +33,7 @@ func main() {
 
 	rootCmd.AddCommand(generateImportsCmd())
 	rootCmd.AddCommand(checkConnectionCmd())
+	rootCmd.AddCommand(listDeviceTypesCmd())
 
 	if err := rootCmd.Execute(); err != nil {
 		fmt.Fprintln(os.Stderr, err)

--- a/docs/index.md
+++ b/docs/index.md
@@ -2,13 +2,13 @@
 page_title: "Terrifi Provider"
 subcategory: ""
 description: |-
-  Terraform provider for managing Ubiquiti UniFi network infrastructure.
+  Terraform provider and CLI for managing Ubiquiti UniFi network infrastructure.
 ---
 
 # Terrifi Provider
 
-The Terrifi provider lets you manage resources on a Ubiquiti UniFi controller.
-It communicates with the UniFi API to create, read, update, and delete network configuration such as DNS records, networks, WLANs, firewall zones, firewall zone rules, and client devices.
+Terrifi is a Terraform provider and CLI for managing Ubiquiti UniFi network infrastructure. The provider communicates with the UniFi API to create, read, update, and delete network configuration such as DNS records, networks, WLANs, firewall zones, firewall policies, and client devices. The CLI provides tools for importing existing infrastructure into Terraform, verifying controller connectivity, and browsing the device fingerprint database.
+
 We leverage hardware-in-the-loop testing to ensure that all resources are fully functional with real UniFi hardware.
 
 ## Example Usage
@@ -87,7 +87,7 @@ The API key is preferred, as it's arguably more secure and I've seen instances o
 
 ## CLI
 
-The Terrifi CLI connects to a live UniFi controller and generates Terraform `import {}` and `resource {}` blocks, making it easy to bring existing infrastructure under Terraform management.
+The Terrifi CLI is a companion tool for working with UniFi controllers. It can generate Terraform import blocks from live infrastructure, verify connectivity, and browse the device fingerprint database.
 
 ### Install
 
@@ -111,7 +111,7 @@ terrifi check-connection
 
 #### generate-imports
 
-Generate Terraform import blocks for a resource type:
+Generate Terraform `import {}` and `resource {}` blocks for a resource type, making it easy to bring existing infrastructure under Terraform management:
 
 ```sh
 terrifi generate-imports <resource_type>
@@ -126,10 +126,11 @@ Supported resource types:
 | `terrifi_dns_record` | DNS records | [dns_record](resources/dns_record.md) |
 | `terrifi_firewall_zone` | Firewall zones | [firewall_zone](resources/firewall_zone.md) |
 | `terrifi_firewall_policy` | Firewall policies | [firewall_policy](resources/firewall_policy.md) |
+| `terrifi_firewall_policy_order` | Firewall policy ordering | [firewall_policy_order](resources/firewall_policy_order.md) |
 | `terrifi_network` | Networks | [network](resources/network.md) |
 | `terrifi_wlan` | Wireless networks | [wlan](resources/wlan.md) |
 
-#### Example
+Example:
 
 ```sh
 terrifi generate-imports terrifi_dns_record > imports.tf
@@ -151,3 +152,19 @@ resource "terrifi_dns_record" "web_example_com" {
 ```
 
 You can then run `terraform plan` to verify and `terraform apply` to complete the import.
+
+#### list-device-types
+
+Browse the UniFi controller's fingerprint database to find device type IDs. These IDs can be used as `dev_id_override` values to set custom icons on client devices. Outputs CSV by default:
+
+```sh
+terrifi list-device-types > device_types.csv
+```
+
+Use the `--html` flag to generate a browsable HTML page (`unifi-device-types.html`) with device icons, fuzzy search, and filterable type/vendor dropdowns:
+
+```sh
+terrifi list-device-types --html
+```
+
+The HTML page loads device icons from Ubiquiti's CDN (`https://static.ui.com/fingerprint/0/{id}_257x257.png`) and uses [Fuse.js](https://www.fusejs.io/) for fuzzy search. Search results are ranked by relevance, and the type/vendor dropdowns update dynamically to only show options that match the current filters.

--- a/internal/provider/fingerprint_api.go
+++ b/internal/provider/fingerprint_api.go
@@ -1,0 +1,78 @@
+package provider
+
+import (
+	"context"
+	"fmt"
+	"net/http"
+	"sort"
+	"strconv"
+)
+
+// FingerprintDevice represents a device type entry from the UniFi controller's
+// fingerprint database. The ID is used with dev_id_override to set custom
+// icons on client devices.
+type FingerprintDevice struct {
+	ID       int64
+	Name     string
+	DevType  string
+	Family   string
+	Vendor   string
+}
+
+// fingerprintAPIResponse is the response from GET v2/api/fingerprint_devices/{version}.
+type fingerprintAPIResponse struct {
+	DevIDs     map[string]fingerprintDevEntry `json:"dev_ids"`
+	DevTypeIDs map[string]string             `json:"dev_type_ids"`
+	FamilyIDs  map[string]string             `json:"family_ids"`
+	VendorIDs  map[string]string             `json:"vendor_ids"`
+}
+
+type fingerprintDevEntry struct {
+	Name      string `json:"name"`
+	DevTypeID string `json:"dev_type_id"`
+	FamilyID  string `json:"family_id"`
+	VendorID  string `json:"vendor_id"`
+}
+
+// ListFingerprintDevices fetches all known device types from the controller's
+// fingerprint database. These can be used as dev_id_override values to set
+// custom icons on client devices.
+//
+// The version parameter selects the fingerprint database edition:
+//   - 0: full/expanded database (~5,600 devices)
+//   - 1: smaller legacy subset (~1,000 devices)
+//
+// Icon URLs follow the pattern:
+//
+//	https://static.ui.com/fingerprint/0/{id}_128x128.png
+func (c *Client) ListFingerprintDevices(ctx context.Context, version int) ([]FingerprintDevice, error) {
+	var resp fingerprintAPIResponse
+	err := c.doV2Request(ctx, http.MethodGet,
+		fmt.Sprintf("%s%s/v2/api/fingerprint_devices/%d", c.BaseURL, c.APIPath, version),
+		nil, &resp)
+	if err != nil {
+		return nil, err
+	}
+
+	devices := make([]FingerprintDevice, 0, len(resp.DevIDs))
+	for idStr, entry := range resp.DevIDs {
+		id, err := strconv.ParseInt(idStr, 10, 64)
+		if err != nil {
+			continue
+		}
+		devices = append(devices, FingerprintDevice{
+			ID:      id,
+			Name:    entry.Name,
+			DevType: resp.DevTypeIDs[entry.DevTypeID],
+			Family:  resp.FamilyIDs[entry.FamilyID],
+			Vendor:  resp.VendorIDs[entry.VendorID],
+		})
+	}
+
+	sort.Slice(devices, func(i, j int) bool {
+		return devices[i].ID < devices[j].ID
+	})
+
+	return devices, nil
+}
+


### PR DESCRIPTION
## Summary

- Adds `terrifi list-device-types` command that queries the controller's v2 fingerprint API (`GET v2/api/fingerprint_devices/0`) to list all ~5,600 known device types
- Outputs CSV by default (id, name, dev_type, family, vendor, icon_url)
- `--html` flag generates a self-contained `unifi-device-types.html` page with:
  - Device icons loaded from Ubiquiti's CDN
  - Fuse.js fuzzy search with relevance-ranked results
  - Type and vendor filter dropdowns that dynamically update based on current filters
- Updates CLI docs to reflect broader CLI scope (not just import generation)
- Adds missing `terrifi_firewall_policy_order` to the generate-imports docs table

## Test plan

- [x] Run `terrifi list-device-types` against a live controller, verify CSV output
- [x] Run `terrifi list-device-types --html`, open the generated page, verify icons load, fuzzy search works, and dropdowns filter correctly
- [x] Verify selecting a type narrows the vendor dropdown and vice versa
- [x] Verify search results are ranked by relevance (e.g. searching "proxmox" shows exact matches first)

🤖 Generated with [Claude Code](https://claude.com/claude-code)