### PR TITLE
Fix setup-task rate limits by passing GITHUB_TOKEN

### DIFF
--- a/internal/provider/client.go
+++ b/internal/provider/client.go
@@ -29,7 +29,7 @@ type Client struct {
 	APIPath string // API path prefix, e.g. "/proxy/network" for UniFi OS, empty for legacy
 	APIKey  string // Stored separately because the SDK's apiKey field is private
 	HTTP    *retryablehttp.Client
-	csrf    string         // CSRF token for custom v2/v1 API requests that bypass the SDK
+	csrf    string // CSRF token for custom v2/v1 API requests that bypass the SDK
 	cache   *responseCache // nil when response caching is disabled (zero overhead)
 }
 
@@ -47,13 +47,13 @@ func (c *Client) SiteOrDefault(site types.String) string {
 // UniFi API client. It can be populated from Terraform attributes, env vars,
 // or both (via ClientConfigFromEnv).
 type ClientConfig struct {
-	APIURL          string
-	Username        string
-	Password        string
-	APIKey          string
-	Site            string
-	AllowInsecure   bool
-	ResponseCaching bool
+	APIURL           string
+	Username         string
+	Password         string
+	APIKey           string
+	Site             string
+	AllowInsecure    bool
+	ResponseCaching  bool
 }
 
 // ClientConfigFromEnv reads UniFi connection configuration from environment

--- a/internal/provider/fingerprint_api.go
+++ b/internal/provider/fingerprint_api.go
@@ -12,19 +12,19 @@ import (
 // fingerprint database. The ID is used with dev_id_override to set custom
 // icons on client devices.
 type FingerprintDevice struct {
-	ID      int64
-	Name    string
-	DevType string
-	Family  string
-	Vendor  string
+	ID       int64
+	Name     string
+	DevType  string
+	Family   string
+	Vendor   string
 }
 
 // fingerprintAPIResponse is the response from GET v2/api/fingerprint_devices/{version}.
 type fingerprintAPIResponse struct {
 	DevIDs     map[string]fingerprintDevEntry `json:"dev_ids"`
-	DevTypeIDs map[string]string              `json:"dev_type_ids"`
-	FamilyIDs  map[string]string              `json:"family_ids"`
-	VendorIDs  map[string]string              `json:"vendor_ids"`
+	DevTypeIDs map[string]string             `json:"dev_type_ids"`
+	FamilyIDs  map[string]string             `json:"family_ids"`
+	VendorIDs  map[string]string             `json:"vendor_ids"`
 }
 
 type fingerprintDevEntry struct {
@@ -75,3 +75,4 @@ func (c *Client) ListFingerprintDevices(ctx context.Context, version int) ([]Fin
 
 	return devices, nil
 }
+

--- a/internal/provider/firewall_policy_order_resource.go
+++ b/internal/provider/firewall_policy_order_resource.go
@@ -30,11 +30,11 @@ type firewallPolicyOrderResource struct {
 }
 
 type firewallPolicyOrderResourceModel struct {
-	ID                types.String `tfsdk:"id"`
-	Site              types.String `tfsdk:"site"`
-	SourceZoneID      types.String `tfsdk:"source_zone_id"`
-	DestinationZoneID types.String `tfsdk:"destination_zone_id"`
-	PolicyIDs         types.List   `tfsdk:"policy_ids"`
+	ID                 types.String `tfsdk:"id"`
+	Site               types.String `tfsdk:"site"`
+	SourceZoneID       types.String `tfsdk:"source_zone_id"`
+	DestinationZoneID  types.String `tfsdk:"destination_zone_id"`
+	PolicyIDs          types.List   `tfsdk:"policy_ids"`
 }
 
 func (r *firewallPolicyOrderResource) Metadata(


### PR DESCRIPTION
## Summary

- Pass `repo-token: ${{ secrets.GITHUB_TOKEN }}` to `arduino/setup-task@v2` in CI workflows to authenticate GitHub API requests (5000/hr vs 60/hr unauthenticated)
- Add `run.sh` to `hardware-testing/github-runner/` that rsyncs files and starts the docker compose stack

Closes #95

## Test plan

- [ ] CI-Local workflow installs Task without rate limit errors
- [ ] CI-HIL workflow installs Task without rate limit errors

🤖 Generated with [Claude Code](https://claude.com/claude-code)