### PR TITLE
Add GitHub Pages site with landing page

### DIFF
--- a/.github/workflows/deploy-site.yaml
+++ b/.github/workflows/deploy-site.yaml
@@ -1,0 +1,37 @@
+name: Deploy Site
+
+on:
+  workflow_dispatch:
+  push:
+    branches: [main]
+    paths:
+      - site/**
+      - .github/workflows/deploy-site.yaml
+
+permissions:
+  pages: write
+  id-token: write
+
+concurrency:
+  group: pages
+  cancel-in-progress: true
+
+jobs:
+  deploy:
+    name: Deploy
+    runs-on: ubuntu-latest
+    environment:
+      name: github-pages
+      url: ${{ steps.deployment.outputs.page_url }}
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Upload Pages artifact
+        uses: actions/upload-pages-artifact@v3
+        with:
+          path: site
+
+      - name: Deploy to GitHub Pages
+        id: deployment
+        uses: actions/deploy-pages@v4

--- a/site/index.html
+++ b/site/index.html
@@ -1,0 +1,40 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="utf-8">
+<meta name="viewport" content="width=device-width, initial-scale=1">
+<title>Terrifi – Terraform Provider for UniFi</title>
+<style>
+  * { box-sizing: border-box; margin: 0; padding: 0; }
+  body {
+    font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, sans-serif;
+    background: #f5f5f5; color: #333;
+    display: flex; justify-content: center; padding: 80px 20px;
+  }
+  .card {
+    max-width: 480px; width: 100%; background: #fff;
+    border-radius: 12px; box-shadow: 0 2px 12px rgba(0,0,0,0.08);
+    padding: 48px 40px; text-align: center;
+  }
+  h1 { font-size: 28px; margin-bottom: 8px; }
+  .tagline { color: #666; font-size: 15px; margin-bottom: 32px; }
+  .links { list-style: none; display: flex; flex-direction: column; gap: 12px; }
+  .links a {
+    display: block; padding: 14px 20px; border-radius: 8px;
+    background: #1a1a2e; color: #fff; text-decoration: none;
+    font-size: 15px; font-weight: 500; transition: background 0.15s;
+  }
+  .links a:hover { background: #2a2a4e; }
+</style>
+</head>
+<body>
+<div class="card">
+  <h1>Terrifi</h1>
+  <p class="tagline">A Terraform provider for UniFi</p>
+  <ul class="links">
+    <li><a href="https://github.com/alexklibisz/terrifi">GitHub Repository</a></li>
+    <li><a href="https://search.opentofu.org/provider/alexklibisz/terrifi/latest">OpenTofu Registry</a></li>
+  </ul>
+</div>
+</body>
+</html>


### PR DESCRIPTION
## Summary
- Add `site/index.html` — minimal landing page linking to the GitHub repo and OpenTofu Registry
- Add `.github/workflows/deploy-site.yaml` — deploys `site/` to GitHub Pages on push to main

## Setup
After merging, go to repo Settings > Pages and set the source to **GitHub Actions**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)