### PR TITLE
Deploy device types page to GitHub Pages

### DIFF
--- a/.github/workflows/deploy-site.yaml
+++ b/.github/workflows/deploy-site.yaml
@@ -6,6 +6,8 @@ on:
     branches: [main]
     paths:
       - site/**
+      - cmd/terrifi/list_device_types.go
+      - internal/provider/fingerprint_api.go
       - .github/workflows/deploy-site.yaml
 
 permissions:
@@ -19,13 +21,38 @@ concurrency:
 jobs:
   deploy:
     name: Deploy
-    runs-on: ubuntu-latest
+    runs-on:
+      - self-hosted
+      - terrifi-hardware-test
+    env:
+      UNIFI_API: https://192.168.1.3:11443
+      UNIFI_API_KEY: ${{ secrets.TERRIFI_HIL_TEST_UNIFI_API_KEY }}
+      UNIFI_INSECURE: true
     environment:
       name: github-pages
       url: ${{ steps.deployment.outputs.page_url }}
     steps:
       - name: Checkout
+        timeout-minutes: 1
         uses: actions/checkout@v4
+
+      - name: Set up Go
+        timeout-minutes: 1
+        uses: actions/setup-go@v5
+        with:
+          go-version-file: go.mod
+          cache: false
+
+      - name: Build CLI
+        timeout-minutes: 5
+        run: go build -o terrifi ./cmd/terrifi
+
+      - name: Generate device types page
+        timeout-minutes: 10
+        run: ./terrifi list-device-types --html
+
+      - name: Assemble site
+        run: cp -r unifi-device-types site/device-types
 
       - name: Upload Pages artifact
         uses: actions/upload-pages-artifact@v3

--- a/site/index.html
+++ b/site/index.html
@@ -34,6 +34,7 @@
   <ul class="links">
     <li><a href="https://github.com/alexklibisz/terrifi">GitHub Repository</a></li>
     <li><a href="https://search.opentofu.org/provider/alexklibisz/terrifi/latest">OpenTofu Registry</a></li>
+    <li><a href="device-types/">UniFi Device Types Browser</a></li>
   </ul>
 </div>
 </body>


### PR DESCRIPTION
## Summary
- Update deploy workflow to run on self-hosted runner with hardware access
- Build CLI and generate device types page via `list-device-types --html`
- Copy generated output into `site/device-types/` before deploying
- Add device types browser link to landing page

## Notes
- Depends on PR #99 being merged first (the `--html` output changes)
- Trigger paths include `cmd/terrifi/list_device_types.go` and `internal/provider/fingerprint_api.go`

🤖 Generated with [Claude Code](https://claude.com/claude-code)