### PR TITLE
Add fixed_ap_mac attribute and terrifi_device data source

### DIFF
--- a/docs/data-sources/device.md
+++ b/docs/data-sources/device.md
@@ -1,0 +1,65 @@
+---
+page_title: "terrifi_device Data Source - Terrifi"
+subcategory: ""
+description: |-
+  Looks up a UniFi network device (access point, switch, or gateway).
+---
+
+# terrifi_device (Data Source)
+
+Looks up a UniFi network device (access point, switch, or gateway) by name or MAC address. Use this data source to reference device attributes in other resources — for example, to pin a client device to a specific access point.
+
+## Example Usage
+
+### Look up by name
+
+```terraform
+data "terrifi_device" "living_room_ap" {
+  name = "Living Room AP"
+}
+```
+
+### Look up by MAC
+
+```terraform
+data "terrifi_device" "office_ap" {
+  mac = "aa:bb:cc:dd:ee:ff"
+}
+```
+
+### Pin a client to an access point
+
+```terraform
+data "terrifi_device" "office_ap" {
+  name = "Office AP"
+}
+
+resource "terrifi_client_device" "laptop" {
+  mac          = "11:22:33:44:55:66"
+  name         = "Work Laptop"
+  fixed_ap_mac = data.terrifi_device.office_ap.mac
+}
+```
+
+## Schema
+
+### Required (one of)
+
+Exactly one of `name` or `mac` must be specified.
+
+- `name` (String) — The name of the device to look up.
+- `mac` (String) — The MAC address of the device to look up (e.g. `aa:bb:cc:dd:ee:ff`).
+
+### Optional
+
+- `site` (String) — The site to look up the device in. Defaults to the provider site.
+
+### Read-Only
+
+- `id` (String) — The ID of the device.
+- `model` (String) — The hardware model of the device (e.g. `U6-LR`, `US-16-XG`).
+- `type` (String) — The device type (e.g. `uap` for access point, `usw` for switch, `ugw` for gateway).
+- `ip` (String) — The current IP address of the device.
+- `disabled` (Boolean) — Whether the device is administratively disabled.
+- `adopted` (Boolean) — Whether the device has been adopted by the controller.
+- `state` (Number) — The device state. 0 = unknown, 1 = connected, 2 = pending, 4 = upgrading, 5 = provisioning, 6 = heartbeat missed.

--- a/docs/resources/client_device.md
+++ b/docs/resources/client_device.md
@@ -7,7 +7,7 @@ description: |-
 
 # terrifi_client_device (Resource)
 
-Manages a client device on the UniFi controller. Use this resource to set aliases, notes, fixed IPs, VLAN overrides, local DNS records, custom device icons, and blocked status for known clients.
+Manages a client device on the UniFi controller. Use this resource to set aliases, notes, fixed IPs, VLAN overrides, local DNS records, custom device icons, AP locking, and blocked status for known clients.
 
 ## Example Usage
 
@@ -98,6 +98,16 @@ resource "terrifi_client_device" "server" {
 }
 ```
 
+### Lock to access point
+
+```terraform
+resource "terrifi_client_device" "laptop" {
+  mac          = "aa:bb:cc:dd:ee:ff"
+  name         = "Work Laptop"
+  fixed_ap_mac = "11:22:33:44:55:66"
+}
+```
+
 ### Block a client
 
 ```terraform
@@ -124,6 +134,7 @@ resource "terrifi_client_device" "blocked" {
 - `local_dns_record` (String) — A local DNS hostname for this client device. Requires `fixed_ip`.
 - `client_group_ids` (Set of String) — Set of client group IDs to assign this device to. Use `terrifi_client_group` to manage groups.
 - `device_type_id` (Number) — The device type ID (fingerprint override) to set a custom icon. Use `terrifi list-device-types` to list IDs as CSV, or `terrifi list-device-types --html` to generate a browsable page with icons and fuzzy search.
+- `fixed_ap_mac` (String) — The MAC address of the access point to lock this client to (e.g. `aa:bb:cc:dd:ee:ff`). When set, the client will only connect to this AP.
 - `blocked` (Boolean) — Whether the client device is blocked from network access. Defaults to `false`.
 - `site` (String) — The site to associate the client device with. Defaults to the provider site. Changing this forces a new resource.
 

--- a/internal/generate/client_device.go
+++ b/internal/generate/client_device.go
@@ -65,6 +65,9 @@ func ClientDeviceBlocks(clients []unifi.Client, overrides map[string]int64) []Re
 				Comment: "use 'terrifi list-device-types' to browse available IDs",
 			})
 		}
+		if c.FixedApEnabled && c.FixedApMAC != "" {
+			block.Attributes = append(block.Attributes, Attr{Key: "fixed_ap_mac", Value: HCLString(c.FixedApMAC)})
+		}
 		if c.Blocked != nil && *c.Blocked {
 			block.Attributes = append(block.Attributes, Attr{Key: "blocked", Value: HCLBool(true)})
 		}

--- a/internal/provider/client_device_api.go
+++ b/internal/provider/client_device_api.go
@@ -35,6 +35,8 @@ type clientDeviceRequest struct {
 	VirtualNetworkOverrideEnabled *bool    `json:"virtual_network_override_enabled,omitempty"`
 	VirtualNetworkOverrideID      string   `json:"virtual_network_override_id,omitempty"`
 	NetworkMembersGroupIDs        []string `json:"network_members_group_ids"`
+	FixedApEnabled                *bool    `json:"fixed_ap_enabled,omitempty"`
+	FixedApMAC                    string   `json:"fixed_ap_mac,omitempty"`
 	Blocked                       *bool    `json:"blocked,omitempty"`
 }
 
@@ -303,6 +305,14 @@ func buildClientDeviceRequest(d *unifi.Client) clientDeviceRequest {
 		req.NetworkMembersGroupIDs = d.NetworkMembersGroupIDs
 	} else {
 		req.NetworkMembersGroupIDs = []string{}
+	}
+
+	// Fixed AP: derive enabled from whether MAC is set
+	if d.FixedApMAC != "" {
+		req.FixedApMAC = d.FixedApMAC
+		req.FixedApEnabled = boolPtr(true)
+	} else {
+		req.FixedApEnabled = boolPtr(false)
 	}
 
 	// Blocked: pass through as-is

--- a/internal/provider/client_device_resource.go
+++ b/internal/provider/client_device_resource.go
@@ -47,6 +47,7 @@ type clientDeviceResourceModel struct {
 	LocalDNSRecord    types.String `tfsdk:"local_dns_record"`
 	ClientGroupIDs    types.Set    `tfsdk:"client_group_ids"`
 	DeviceTypeID      types.Int64  `tfsdk:"device_type_id"`
+	FixedApMAC        types.String `tfsdk:"fixed_ap_mac"`
 	Blocked           types.Bool   `tfsdk:"blocked"`
 }
 
@@ -65,7 +66,7 @@ func (r *clientDeviceResource) Schema(
 ) {
 	resp.Schema = schema.Schema{
 		MarkdownDescription: "Manages a client device on the UniFi controller. Use this resource to set " +
-			"aliases, notes, fixed IPs, VLAN overrides, local DNS records, custom device icons, and blocked status for known clients.",
+			"aliases, notes, fixed IPs, VLAN overrides, local DNS records, custom device icons, AP locking, and blocked status for known clients.",
 
 		Attributes: map[string]schema.Attribute{
 			"id": schema.StringAttribute{
@@ -155,6 +156,18 @@ func (r *clientDeviceResource) Schema(
 					"client device. Use `terrifi list-device-types` to list IDs as CSV, or " +
 					"`terrifi list-device-types --html` to generate a browsable page with icons and fuzzy search.",
 				Optional: true,
+			},
+
+			"fixed_ap_mac": schema.StringAttribute{
+				MarkdownDescription: "The MAC address of the access point to lock this client to " +
+					"(e.g. `aa:bb:cc:dd:ee:ff`). When set, the client will only connect to this AP.",
+				Optional: true,
+				Validators: []validator.String{
+					stringvalidator.RegexMatches(
+						macRegexp,
+						"must be a valid MAC address (e.g. aa:bb:cc:dd:ee:ff)",
+					),
+				},
 			},
 
 			"blocked": schema.BoolAttribute{
@@ -530,6 +543,11 @@ func (r *clientDeviceResource) applyPlanToState(plan, state *clientDeviceResourc
 	} else {
 		state.DeviceTypeID = types.Int64Null()
 	}
+	if !plan.FixedApMAC.IsNull() && !plan.FixedApMAC.IsUnknown() {
+		state.FixedApMAC = plan.FixedApMAC
+	} else {
+		state.FixedApMAC = types.StringNull()
+	}
 	if !plan.Blocked.IsNull() && !plan.Blocked.IsUnknown() {
 		state.Blocked = plan.Blocked
 	} else {
@@ -574,6 +592,11 @@ func (r *clientDeviceResource) modelToAPI(ctx context.Context, m *clientDeviceRe
 		c.NetworkMembersGroupIDs = ids
 	}
 
+	if !m.FixedApMAC.IsNull() && !m.FixedApMAC.IsUnknown() {
+		c.FixedApMAC = strings.ToLower(m.FixedApMAC.ValueString())
+		c.FixedApEnabled = true
+	}
+
 	if !m.Blocked.IsNull() && !m.Blocked.IsUnknown() {
 		v := m.Blocked.ValueBool()
 		c.Blocked = &v
@@ -611,6 +634,13 @@ func (r *clientDeviceResource) apiToModel(c *unifi.Client, m *clientDeviceResour
 		m.LocalDNSRecord = types.StringValue(c.LocalDNSRecord)
 	} else {
 		m.LocalDNSRecord = types.StringNull()
+	}
+
+	// Only populate fixed AP MAC when the controller says it's enabled and has a value.
+	if c.FixedApEnabled && c.FixedApMAC != "" {
+		m.FixedApMAC = types.StringValue(c.FixedApMAC)
+	} else {
+		m.FixedApMAC = types.StringNull()
 	}
 
 	if c.NetworkMembersGroupIDs != nil {

--- a/internal/provider/client_device_resource_test.go
+++ b/internal/provider/client_device_resource_test.go
@@ -54,6 +54,8 @@ func TestClientDeviceModelToAPI(t *testing.T) {
 		assert.Nil(t, c.VirtualNetworkOverrideEnabled)
 		assert.Empty(t, c.VirtualNetworkOverrideID)
 		assert.Nil(t, c.NetworkMembersGroupIDs)
+		assert.Empty(t, c.FixedApMAC)
+		assert.False(t, c.FixedApEnabled)
 		assert.Nil(t, c.Blocked)
 	})
 
@@ -69,7 +71,8 @@ func TestClientDeviceModelToAPI(t *testing.T) {
 			ClientGroupIDs: types.SetValueMust(types.StringType, []attr.Value{
 				types.StringValue("group-789"),
 			}),
-			Blocked: types.BoolValue(true),
+			FixedApMAC: types.StringValue("11:22:33:44:55:66"),
+			Blocked:    types.BoolValue(true),
 		}
 
 		c := r.modelToAPI(ctx, model)
@@ -86,6 +89,8 @@ func TestClientDeviceModelToAPI(t *testing.T) {
 		assert.Equal(t, "mydevice.local", c.LocalDNSRecord)
 		assert.True(t, c.LocalDNSRecordEnabled)
 		assert.Equal(t, []string{"group-789"}, c.NetworkMembersGroupIDs)
+		assert.Equal(t, "11:22:33:44:55:66", c.FixedApMAC)
+		assert.True(t, c.FixedApEnabled)
 		assert.NotNil(t, c.Blocked)
 		assert.True(t, *c.Blocked)
 	})
@@ -143,6 +148,42 @@ func TestClientDeviceModelToAPI(t *testing.T) {
 		assert.Equal(t, "override-789", c.VirtualNetworkOverrideID)
 		assert.NotNil(t, c.VirtualNetworkOverrideEnabled)
 		assert.True(t, *c.VirtualNetworkOverrideEnabled)
+	})
+
+	t.Run("fixed_ap_mac sets fixed_ap_enabled", func(t *testing.T) {
+		model := &clientDeviceResourceModel{
+			MAC:        types.StringValue("aa:bb:cc:dd:ee:ff"),
+			FixedApMAC: types.StringValue("11:22:33:44:55:66"),
+		}
+
+		c := r.modelToAPI(ctx, model)
+
+		assert.Equal(t, "11:22:33:44:55:66", c.FixedApMAC)
+		assert.True(t, c.FixedApEnabled)
+	})
+
+	t.Run("fixed_ap_mac uppercase normalized", func(t *testing.T) {
+		model := &clientDeviceResourceModel{
+			MAC:        types.StringValue("aa:bb:cc:dd:ee:ff"),
+			FixedApMAC: types.StringValue("AA:BB:CC:DD:EE:FF"),
+		}
+
+		c := r.modelToAPI(ctx, model)
+
+		assert.Equal(t, "aa:bb:cc:dd:ee:ff", c.FixedApMAC)
+		assert.True(t, c.FixedApEnabled)
+	})
+
+	t.Run("fixed_ap_mac null does not set fixed_ap_enabled", func(t *testing.T) {
+		model := &clientDeviceResourceModel{
+			MAC:        types.StringValue("aa:bb:cc:dd:ee:ff"),
+			FixedApMAC: types.StringNull(),
+		}
+
+		c := r.modelToAPI(ctx, model)
+
+		assert.Empty(t, c.FixedApMAC)
+		assert.False(t, c.FixedApEnabled)
 	})
 
 	t.Run("blocked true", func(t *testing.T) {
@@ -316,6 +357,32 @@ func TestBuildClientDeviceRequest(t *testing.T) {
 		assert.True(t, *req.VirtualNetworkOverrideEnabled)
 	})
 
+	t.Run("fixed_ap_mac set", func(t *testing.T) {
+		c := &unifi.Client{
+			MAC:            "aa:bb:cc:dd:ee:ff",
+			FixedApMAC:     "11:22:33:44:55:66",
+			FixedApEnabled: true,
+		}
+
+		req := buildClientDeviceRequest(c)
+
+		assert.Equal(t, "11:22:33:44:55:66", req.FixedApMAC)
+		assert.NotNil(t, req.FixedApEnabled)
+		assert.True(t, *req.FixedApEnabled)
+	})
+
+	t.Run("fixed_ap_mac empty", func(t *testing.T) {
+		c := &unifi.Client{
+			MAC: "aa:bb:cc:dd:ee:ff",
+		}
+
+		req := buildClientDeviceRequest(c)
+
+		assert.Empty(t, req.FixedApMAC)
+		assert.NotNil(t, req.FixedApEnabled)
+		assert.False(t, *req.FixedApEnabled)
+	})
+
 	t.Run("all fields together", func(t *testing.T) {
 		blocked := true
 		c := &unifi.Client{
@@ -327,6 +394,7 @@ func TestBuildClientDeviceRequest(t *testing.T) {
 			VirtualNetworkOverrideID: "vlan-456",
 			LocalDNSRecord:           "test.local",
 			NetworkMembersGroupIDs:   []string{"group-789", "group-abc"},
+			FixedApMAC:               "11:22:33:44:55:66",
 			Blocked:                  &blocked,
 		}
 
@@ -348,6 +416,9 @@ func TestBuildClientDeviceRequest(t *testing.T) {
 		assert.NotNil(t, req.LocalDNSRecordEnabled)
 		assert.True(t, *req.LocalDNSRecordEnabled)
 		assert.Equal(t, []string{"group-789", "group-abc"}, req.NetworkMembersGroupIDs)
+		assert.Equal(t, "11:22:33:44:55:66", req.FixedApMAC)
+		assert.NotNil(t, req.FixedApEnabled)
+		assert.True(t, *req.FixedApEnabled)
 		assert.NotNil(t, req.Blocked)
 		assert.True(t, *req.Blocked)
 	})
@@ -411,6 +482,7 @@ func TestClientDeviceAPIToModel(t *testing.T) {
 		assert.True(t, model.NetworkOverrideID.IsNull(), "NetworkOverrideID should be null")
 		assert.True(t, model.LocalDNSRecord.IsNull(), "LocalDNSRecord should be null")
 		assert.True(t, model.ClientGroupIDs.IsNull(), "ClientGroupIDs should be null")
+		assert.True(t, model.FixedApMAC.IsNull(), "FixedApMAC should be null")
 		assert.False(t, model.Blocked.ValueBool(), "Blocked should default to false")
 	})
 
@@ -430,6 +502,8 @@ func TestClientDeviceAPIToModel(t *testing.T) {
 			LocalDNSRecord:                "mydevice.local",
 			LocalDNSRecordEnabled:         true,
 			NetworkMembersGroupIDs:        []string{"group-xyz"},
+			FixedApMAC:                    "aa:bb:cc:dd:ee:ff",
+			FixedApEnabled:                true,
 			Blocked:                       &blocked,
 		}
 
@@ -447,6 +521,7 @@ func TestClientDeviceAPIToModel(t *testing.T) {
 		assert.Equal(t, "mydevice.local", model.LocalDNSRecord.ValueString())
 		expected := types.SetValueMust(types.StringType, []attr.Value{types.StringValue("group-xyz")})
 		assert.True(t, model.ClientGroupIDs.Equal(expected), "ClientGroupIDs should contain group-xyz")
+		assert.Equal(t, "aa:bb:cc:dd:ee:ff", model.FixedApMAC.ValueString())
 		assert.True(t, model.Blocked.ValueBool())
 	})
 
@@ -496,6 +571,47 @@ func TestClientDeviceAPIToModel(t *testing.T) {
 		r.apiToModel(c, &model, "default")
 
 		assert.True(t, model.LocalDNSRecord.IsNull(), "LocalDNSRecord should be null when disabled")
+	})
+
+	t.Run("fixed_ap_enabled true with MAC", func(t *testing.T) {
+		c := &unifi.Client{
+			ID:             "client-ap1",
+			MAC:            "aa:bb:cc:dd:ee:ff",
+			FixedApMAC:     "11:22:33:44:55:66",
+			FixedApEnabled: true,
+		}
+
+		var model clientDeviceResourceModel
+		r.apiToModel(c, &model, "default")
+
+		assert.Equal(t, "11:22:33:44:55:66", model.FixedApMAC.ValueString())
+	})
+
+	t.Run("fixed_ap_enabled false with stale MAC", func(t *testing.T) {
+		c := &unifi.Client{
+			ID:             "client-ap2",
+			MAC:            "aa:bb:cc:dd:ee:ff",
+			FixedApMAC:     "11:22:33:44:55:66",
+			FixedApEnabled: false,
+		}
+
+		var model clientDeviceResourceModel
+		r.apiToModel(c, &model, "default")
+
+		assert.True(t, model.FixedApMAC.IsNull(), "FixedApMAC should be null when disabled")
+	})
+
+	t.Run("fixed_ap_enabled true with empty MAC", func(t *testing.T) {
+		c := &unifi.Client{
+			ID:             "client-ap3",
+			MAC:            "aa:bb:cc:dd:ee:ff",
+			FixedApEnabled: true,
+		}
+
+		var model clientDeviceResourceModel
+		r.apiToModel(c, &model, "default")
+
+		assert.True(t, model.FixedApMAC.IsNull(), "FixedApMAC should be null when MAC is empty")
 	})
 
 	t.Run("blocked nil", func(t *testing.T) {
@@ -1672,6 +1788,170 @@ resource "terrifi_client_device" "test" {
 				// Apply the same config again — should produce no diff.
 				Config:   config,
 				PlanOnly: true,
+			},
+		},
+	})
+}
+
+func TestAccClientDevice_fixedApMAC(t *testing.T) {
+	mac := randomMAC()
+	apMAC := randomMAC()
+	resource.Test(t, resource.TestCase{
+		PreCheck:                 func() { preCheck(t) },
+		ProtoV6ProviderFactories: testAccProtoV6ProviderFactories,
+		Steps: []resource.TestStep{
+			{
+				Config: fmt.Sprintf(`
+resource "terrifi_client_device" "test" {
+  mac          = %q
+  name         = "tfacc-fixedap"
+  fixed_ap_mac = %q
+}
+`, mac, apMAC),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr("terrifi_client_device.test", "name", "tfacc-fixedap"),
+					resource.TestCheckResourceAttr("terrifi_client_device.test", "fixed_ap_mac", apMAC),
+				),
+			},
+		},
+	})
+}
+
+func TestAccClientDevice_fixedApMACAddRemove(t *testing.T) {
+	mac := randomMAC()
+	apMAC := randomMAC()
+	resource.Test(t, resource.TestCase{
+		PreCheck:                 func() { preCheck(t) },
+		ProtoV6ProviderFactories: testAccProtoV6ProviderFactories,
+		Steps: []resource.TestStep{
+			// Step 1: Create without fixed_ap_mac
+			{
+				Config: fmt.Sprintf(`
+resource "terrifi_client_device" "test" {
+  mac  = %q
+  name = "tfacc-fixedap-toggle"
+}
+`, mac),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckNoResourceAttr("terrifi_client_device.test", "fixed_ap_mac"),
+				),
+			},
+			// Step 2: Add fixed_ap_mac
+			{
+				Config: fmt.Sprintf(`
+resource "terrifi_client_device" "test" {
+  mac          = %q
+  name         = "tfacc-fixedap-toggle"
+  fixed_ap_mac = %q
+}
+`, mac, apMAC),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr("terrifi_client_device.test", "fixed_ap_mac", apMAC),
+				),
+			},
+			// Step 3: Remove fixed_ap_mac
+			{
+				Config: fmt.Sprintf(`
+resource "terrifi_client_device" "test" {
+  mac  = %q
+  name = "tfacc-fixedap-toggle"
+}
+`, mac),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckNoResourceAttr("terrifi_client_device.test", "fixed_ap_mac"),
+				),
+			},
+		},
+	})
+}
+
+func TestAccClientDevice_fixedApMACChange(t *testing.T) {
+	mac := randomMAC()
+	apMAC1 := randomMAC()
+	apMAC2 := randomMAC()
+	resource.Test(t, resource.TestCase{
+		PreCheck:                 func() { preCheck(t) },
+		ProtoV6ProviderFactories: testAccProtoV6ProviderFactories,
+		Steps: []resource.TestStep{
+			// Step 1: Create with first AP MAC
+			{
+				Config: fmt.Sprintf(`
+resource "terrifi_client_device" "test" {
+  mac          = %q
+  name         = "tfacc-fixedap-change"
+  fixed_ap_mac = %q
+}
+`, mac, apMAC1),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr("terrifi_client_device.test", "fixed_ap_mac", apMAC1),
+				),
+			},
+			// Step 2: Change to a different AP MAC
+			{
+				Config: fmt.Sprintf(`
+resource "terrifi_client_device" "test" {
+  mac          = %q
+  name         = "tfacc-fixedap-change"
+  fixed_ap_mac = %q
+}
+`, mac, apMAC2),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr("terrifi_client_device.test", "fixed_ap_mac", apMAC2),
+				),
+			},
+		},
+	})
+}
+
+func TestAccClientDevice_fixedApMACIdempotent(t *testing.T) {
+	mac := randomMAC()
+	apMAC := randomMAC()
+	config := fmt.Sprintf(`
+resource "terrifi_client_device" "test" {
+  mac          = %q
+  name         = "tfacc-fixedap-idempotent"
+  fixed_ap_mac = %q
+}
+`, mac, apMAC)
+	resource.Test(t, resource.TestCase{
+		PreCheck:                 func() { preCheck(t) },
+		ProtoV6ProviderFactories: testAccProtoV6ProviderFactories,
+		Steps: []resource.TestStep{
+			{
+				Config: config,
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr("terrifi_client_device.test", "fixed_ap_mac", apMAC),
+				),
+			},
+			{
+				// Apply the same config again — should produce no diff.
+				Config:   config,
+				PlanOnly: true,
+			},
+		},
+	})
+}
+
+func TestAccClientDevice_fixedApMACImport(t *testing.T) {
+	mac := randomMAC()
+	apMAC := randomMAC()
+	resource.Test(t, resource.TestCase{
+		PreCheck:                 func() { preCheck(t) },
+		ProtoV6ProviderFactories: testAccProtoV6ProviderFactories,
+		Steps: []resource.TestStep{
+			{
+				Config: fmt.Sprintf(`
+resource "terrifi_client_device" "test" {
+  mac          = %q
+  name         = "tfacc-fixedap-import"
+  fixed_ap_mac = %q
+}
+`, mac, apMAC),
+			},
+			{
+				ResourceName:      "terrifi_client_device.test",
+				ImportState:       true,
+				ImportStateVerify: true,
 			},
 		},
 	})

--- a/internal/provider/device_data_source.go
+++ b/internal/provider/device_data_source.go
@@ -1,0 +1,209 @@
+package provider
+
+import (
+	"context"
+	"fmt"
+	"strings"
+
+	"github.com/hashicorp/terraform-plugin-framework-validators/stringvalidator"
+	"github.com/hashicorp/terraform-plugin-framework/datasource"
+	"github.com/hashicorp/terraform-plugin-framework/datasource/schema"
+	"github.com/hashicorp/terraform-plugin-framework/path"
+	"github.com/hashicorp/terraform-plugin-framework/schema/validator"
+	"github.com/hashicorp/terraform-plugin-framework/types"
+	"github.com/ubiquiti-community/go-unifi/unifi"
+)
+
+var _ datasource.DataSource = &deviceDataSource{}
+
+func NewDeviceDataSource() datasource.DataSource {
+	return &deviceDataSource{}
+}
+
+type deviceDataSource struct {
+	client *Client
+}
+
+type deviceDataSourceModel struct {
+	ID       types.String `tfsdk:"id"`
+	Site     types.String `tfsdk:"site"`
+	MAC      types.String `tfsdk:"mac"`
+	Name     types.String `tfsdk:"name"`
+	Model    types.String `tfsdk:"model"`
+	Type     types.String `tfsdk:"type"`
+	IP       types.String `tfsdk:"ip"`
+	Disabled types.Bool   `tfsdk:"disabled"`
+	Adopted  types.Bool   `tfsdk:"adopted"`
+	State    types.Int64  `tfsdk:"state"`
+}
+
+func (d *deviceDataSource) Metadata(
+	_ context.Context,
+	req datasource.MetadataRequest,
+	resp *datasource.MetadataResponse,
+) {
+	resp.TypeName = req.ProviderTypeName + "_device"
+}
+
+func (d *deviceDataSource) Schema(
+	_ context.Context,
+	_ datasource.SchemaRequest,
+	resp *datasource.SchemaResponse,
+) {
+	resp.Schema = schema.Schema{
+		MarkdownDescription: "Looks up a UniFi network device (access point, switch, or gateway) by name or MAC address.",
+
+		Attributes: map[string]schema.Attribute{
+			"name": schema.StringAttribute{
+				MarkdownDescription: "The name of the device to look up. Exactly one of `name` or `mac` must be specified.",
+				Optional:            true,
+				Validators: []validator.String{
+					stringvalidator.ExactlyOneOf(path.MatchRoot("mac")),
+					stringvalidator.LengthAtLeast(1),
+				},
+			},
+
+			"mac": schema.StringAttribute{
+				MarkdownDescription: "The MAC address of the device to look up (e.g. `aa:bb:cc:dd:ee:ff`). " +
+					"Exactly one of `name` or `mac` must be specified.",
+				Optional: true,
+				Validators: []validator.String{
+					stringvalidator.RegexMatches(
+						macRegexp,
+						"must be a valid MAC address (e.g. aa:bb:cc:dd:ee:ff)",
+					),
+				},
+			},
+
+			"site": schema.StringAttribute{
+				MarkdownDescription: "The site to look up the device in. Defaults to the provider site.",
+				Optional:            true,
+			},
+
+			"id": schema.StringAttribute{
+				MarkdownDescription: "The ID of the device.",
+				Computed:            true,
+			},
+
+			"model": schema.StringAttribute{
+				MarkdownDescription: "The hardware model of the device (e.g. `U6-LR`, `US-16-XG`).",
+				Computed:            true,
+			},
+
+			"type": schema.StringAttribute{
+				MarkdownDescription: "The device type (e.g. `uap` for access point, `usw` for switch, `ugw` for gateway).",
+				Computed:            true,
+			},
+
+			"ip": schema.StringAttribute{
+				MarkdownDescription: "The current IP address of the device.",
+				Computed:            true,
+			},
+
+			"disabled": schema.BoolAttribute{
+				MarkdownDescription: "Whether the device is administratively disabled.",
+				Computed:            true,
+			},
+
+			"adopted": schema.BoolAttribute{
+				MarkdownDescription: "Whether the device has been adopted by the controller.",
+				Computed:            true,
+			},
+
+			"state": schema.Int64Attribute{
+				MarkdownDescription: "The device state. 0 = unknown, 1 = connected, 2 = pending, " +
+					"4 = upgrading, 5 = provisioning, 6 = heartbeat missed.",
+				Computed: true,
+			},
+		},
+	}
+}
+
+func (d *deviceDataSource) Configure(
+	_ context.Context,
+	req datasource.ConfigureRequest,
+	resp *datasource.ConfigureResponse,
+) {
+	if req.ProviderData == nil {
+		return
+	}
+
+	client, ok := req.ProviderData.(*Client)
+	if !ok {
+		resp.Diagnostics.AddError(
+			"Unexpected Data Source Configure Type",
+			fmt.Sprintf("Expected *Client, got: %T.", req.ProviderData),
+		)
+		return
+	}
+
+	d.client = client
+}
+
+func (d *deviceDataSource) Read(
+	ctx context.Context,
+	req datasource.ReadRequest,
+	resp *datasource.ReadResponse,
+) {
+	var config deviceDataSourceModel
+	resp.Diagnostics.Append(req.Config.Get(ctx, &config)...)
+	if resp.Diagnostics.HasError() {
+		return
+	}
+
+	site := d.client.SiteOrDefault(config.Site)
+
+	var device *unifi.Device
+	var err error
+
+	if !config.MAC.IsNull() && !config.MAC.IsUnknown() {
+		mac := strings.ToLower(config.MAC.ValueString())
+		device, err = d.client.ApiClient.GetDeviceByMAC(ctx, site, mac)
+		if err != nil {
+			resp.Diagnostics.AddError(
+				"Device Not Found",
+				fmt.Sprintf("No device found with MAC %q in site %q: %s", mac, site, err.Error()),
+			)
+			return
+		}
+	} else {
+		name := config.Name.ValueString()
+		device, err = d.findDeviceByName(ctx, site, name)
+		if err != nil {
+			resp.Diagnostics.AddError(
+				"Device Not Found",
+				fmt.Sprintf("No device found with name %q in site %q: %s", name, site, err.Error()),
+			)
+			return
+		}
+	}
+
+	d.apiToModel(device, &config, site)
+	resp.Diagnostics.Append(resp.State.Set(ctx, &config)...)
+}
+
+func (d *deviceDataSource) findDeviceByName(ctx context.Context, site, name string) (*unifi.Device, error) {
+	devices, err := d.client.ApiClient.ListDevice(ctx, site)
+	if err != nil {
+		return nil, err
+	}
+	for i := range devices {
+		if devices[i].Name == name {
+			return &devices[i], nil
+		}
+	}
+	return nil, fmt.Errorf("not found")
+}
+
+func (d *deviceDataSource) apiToModel(dev *unifi.Device, m *deviceDataSourceModel, site string) {
+	m.ID = types.StringValue(dev.ID)
+	m.Site = types.StringValue(site)
+	m.MAC = types.StringValue(dev.MAC)
+	m.Name = stringValueOrNull(dev.Name)
+	m.Model = stringValueOrNull(dev.Model)
+	m.Type = stringValueOrNull(dev.Type)
+	m.IP = stringValueOrNull(dev.IP)
+	m.Disabled = types.BoolValue(dev.Disabled)
+	m.Adopted = types.BoolValue(dev.Adopted)
+	m.State = types.Int64Value(int64(dev.State))
+}

--- a/internal/provider/device_data_source_test.go
+++ b/internal/provider/device_data_source_test.go
@@ -1,0 +1,301 @@
+package provider
+
+import (
+	"fmt"
+	"regexp"
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
+	"github.com/stretchr/testify/assert"
+	"github.com/ubiquiti-community/go-unifi/unifi"
+)
+
+// ---------------------------------------------------------------------------
+// Unit tests — no TF_ACC, no network, no env vars needed
+// ---------------------------------------------------------------------------
+
+func TestDeviceDataSourceAPIToModel(t *testing.T) {
+	d := &deviceDataSource{}
+
+	t.Run("full device", func(t *testing.T) {
+		dev := &unifi.Device{
+			ID:       "dev-123",
+			MAC:      "aa:bb:cc:dd:ee:ff",
+			Name:     "Living Room AP",
+			Model:    "U6-LR",
+			Type:     "uap",
+			IP:       "192.168.1.10",
+			Disabled: false,
+			Adopted:  true,
+			State:    unifi.DeviceStateConnected,
+		}
+
+		var model deviceDataSourceModel
+		d.apiToModel(dev, &model, "default")
+
+		assert.Equal(t, "dev-123", model.ID.ValueString())
+		assert.Equal(t, "default", model.Site.ValueString())
+		assert.Equal(t, "aa:bb:cc:dd:ee:ff", model.MAC.ValueString())
+		assert.Equal(t, "Living Room AP", model.Name.ValueString())
+		assert.Equal(t, "U6-LR", model.Model.ValueString())
+		assert.Equal(t, "uap", model.Type.ValueString())
+		assert.Equal(t, "192.168.1.10", model.IP.ValueString())
+		assert.False(t, model.Disabled.ValueBool())
+		assert.True(t, model.Adopted.ValueBool())
+		assert.Equal(t, int64(1), model.State.ValueInt64())
+	})
+
+	t.Run("minimal device", func(t *testing.T) {
+		dev := &unifi.Device{
+			ID:  "dev-456",
+			MAC: "11:22:33:44:55:66",
+		}
+
+		var model deviceDataSourceModel
+		d.apiToModel(dev, &model, "mysite")
+
+		assert.Equal(t, "dev-456", model.ID.ValueString())
+		assert.Equal(t, "mysite", model.Site.ValueString())
+		assert.Equal(t, "11:22:33:44:55:66", model.MAC.ValueString())
+		assert.True(t, model.Name.IsNull())
+		assert.True(t, model.Model.IsNull())
+		assert.True(t, model.Type.IsNull())
+		assert.True(t, model.IP.IsNull())
+		assert.False(t, model.Disabled.ValueBool())
+		assert.False(t, model.Adopted.ValueBool())
+		assert.Equal(t, int64(0), model.State.ValueInt64())
+	})
+
+	t.Run("disabled device", func(t *testing.T) {
+		dev := &unifi.Device{
+			ID:       "dev-789",
+			MAC:      "aa:bb:cc:dd:ee:ff",
+			Disabled: true,
+			Adopted:  true,
+			State:    unifi.DeviceStateConnected,
+		}
+
+		var model deviceDataSourceModel
+		d.apiToModel(dev, &model, "default")
+
+		assert.True(t, model.Disabled.ValueBool())
+		assert.True(t, model.Adopted.ValueBool())
+	})
+}
+
+// ---------------------------------------------------------------------------
+// Acceptance tests — require TF_ACC=1 and a UniFi controller
+// ---------------------------------------------------------------------------
+
+// TestAccDeviceDataSource_byMAC looks up a device by MAC. This test requires
+// at least one adopted device on the controller. It creates a client device
+// resource first (which always works), then uses the data source to look up
+// the controller's own devices by listing them.
+func TestAccDeviceDataSource_byMAC(t *testing.T) {
+	// This test discovers a real device from the controller, so it uses a
+	// two-step approach: first list devices to find a MAC, then look it up.
+	// We use a config that references a data source with a known device.
+	// Since we can't predict which devices exist, we use a helper that
+	// finds the first adopted device.
+	resource.Test(t, resource.TestCase{
+		PreCheck: func() {
+			preCheck(t)
+			// Ensure at least one device exists
+			requireAdoptedDevice(t)
+		},
+		ProtoV6ProviderFactories: testAccProtoV6ProviderFactories,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccDeviceDataSourceByMACConfig(t),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttrSet("data.terrifi_device.test", "id"),
+					resource.TestCheckResourceAttrSet("data.terrifi_device.test", "mac"),
+					resource.TestCheckResourceAttrSet("data.terrifi_device.test", "model"),
+					resource.TestCheckResourceAttrSet("data.terrifi_device.test", "type"),
+					resource.TestCheckResourceAttr("data.terrifi_device.test", "adopted", "true"),
+				),
+			},
+		},
+	})
+}
+
+func TestAccDeviceDataSource_byName(t *testing.T) {
+	resource.Test(t, resource.TestCase{
+		PreCheck: func() {
+			preCheck(t)
+			requireAdoptedDevice(t)
+		},
+		ProtoV6ProviderFactories: testAccProtoV6ProviderFactories,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccDeviceDataSourceByNameConfig(t),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttrSet("data.terrifi_device.test", "id"),
+					resource.TestCheckResourceAttrSet("data.terrifi_device.test", "mac"),
+					resource.TestCheckResourceAttrSet("data.terrifi_device.test", "model"),
+					resource.TestCheckResourceAttrSet("data.terrifi_device.test", "type"),
+					resource.TestCheckResourceAttr("data.terrifi_device.test", "adopted", "true"),
+				),
+			},
+		},
+	})
+}
+
+func TestAccDeviceDataSource_withClientDevice(t *testing.T) {
+	mac := randomMAC()
+	resource.Test(t, resource.TestCase{
+		PreCheck: func() {
+			preCheck(t)
+			requireAdoptedDevice(t)
+		},
+		ProtoV6ProviderFactories: testAccProtoV6ProviderFactories,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccDeviceDataSourceWithClientDeviceConfig(t, mac),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttrSet("data.terrifi_device.test", "mac"),
+					resource.TestCheckResourceAttrPair(
+						"terrifi_client_device.test", "fixed_ap_mac",
+						"data.terrifi_device.test", "mac",
+					),
+				),
+			},
+		},
+	})
+}
+
+// ---------------------------------------------------------------------------
+// Test helpers
+// ---------------------------------------------------------------------------
+
+// requireAdoptedDevice skips the test if no adopted device exists on the controller.
+func requireAdoptedDevice(t *testing.T) {
+	t.Helper()
+	dev := findFirstAdoptedDevice(t)
+	if dev == nil {
+		t.Skip("no adopted devices found on controller — skipping device data source test")
+	}
+}
+
+// findFirstAdoptedDevice connects to the controller and returns the first
+// adopted device, or nil if none exist.
+func findFirstAdoptedDevice(t *testing.T) *unifi.Device {
+	t.Helper()
+	client := testAccGetClient(t)
+	devices, err := client.ApiClient.ListDevice(t.Context(), "default")
+	if err != nil {
+		t.Fatalf("failed to list devices: %s", err)
+	}
+	for i := range devices {
+		if devices[i].Adopted {
+			return &devices[i]
+		}
+	}
+	return nil
+}
+
+func testAccDeviceDataSourceByMACConfig(t *testing.T) string {
+	t.Helper()
+	dev := findFirstAdoptedDevice(t)
+	return fmt.Sprintf(`
+data "terrifi_device" "test" {
+  mac = %q
+}
+`, dev.MAC)
+}
+
+func testAccDeviceDataSourceByNameConfig(t *testing.T) string {
+	t.Helper()
+	dev := findFirstAdoptedDevice(t)
+	if dev.Name == "" {
+		t.Skip("first adopted device has no name — skipping name lookup test")
+	}
+	return fmt.Sprintf(`
+data "terrifi_device" "test" {
+  name = %q
+}
+`, dev.Name)
+}
+
+func testAccDeviceDataSourceWithClientDeviceConfig(t *testing.T, clientMAC string) string {
+	t.Helper()
+	dev := findFirstAdoptedDevice(t)
+	return fmt.Sprintf(`
+data "terrifi_device" "test" {
+  mac = %q
+}
+
+resource "terrifi_client_device" "test" {
+  mac          = %q
+  name         = "tfacc-ds-fixedap"
+  fixed_ap_mac = data.terrifi_device.test.mac
+}
+`, dev.MAC, clientMAC)
+}
+
+// testAccGetClient builds an authenticated Client for use in test helpers.
+// It reuses the same env-var-based config as the provider itself.
+func testAccGetClient(t *testing.T) *Client {
+	t.Helper()
+	cfg := ClientConfigFromEnv()
+	client, err := NewClient(t.Context(), cfg)
+	if err != nil {
+		t.Fatalf("failed to create test client: %s", err)
+	}
+	return client
+}
+
+// ---------------------------------------------------------------------------
+// Validation tests (no controller needed)
+// ---------------------------------------------------------------------------
+
+func TestAccDeviceDataSource_validationBothNameAndMAC(t *testing.T) {
+	resource.Test(t, resource.TestCase{
+		PreCheck:                 func() { preCheck(t) },
+		ProtoV6ProviderFactories: testAccProtoV6ProviderFactories,
+		Steps: []resource.TestStep{
+			{
+				Config: `
+data "terrifi_device" "test" {
+  name = "some-device"
+  mac  = "aa:bb:cc:dd:ee:ff"
+}
+`,
+				ExpectError: regexp.MustCompile(`(?i)Invalid Attribute Combination`),
+			},
+		},
+	})
+}
+
+func TestAccDeviceDataSource_validationNeitherNameNorMAC(t *testing.T) {
+	resource.Test(t, resource.TestCase{
+		PreCheck:                 func() { preCheck(t) },
+		ProtoV6ProviderFactories: testAccProtoV6ProviderFactories,
+		Steps: []resource.TestStep{
+			{
+				Config: `
+data "terrifi_device" "test" {
+}
+`,
+				ExpectError: regexp.MustCompile(`(?i)Invalid Attribute Combination`),
+			},
+		},
+	})
+}
+
+func TestAccDeviceDataSource_validationInvalidMAC(t *testing.T) {
+	resource.Test(t, resource.TestCase{
+		PreCheck:                 func() { preCheck(t) },
+		ProtoV6ProviderFactories: testAccProtoV6ProviderFactories,
+		Steps: []resource.TestStep{
+			{
+				Config: `
+data "terrifi_device" "test" {
+  mac = "not-a-mac"
+}
+`,
+				ExpectError: regexp.MustCompile(`must be a valid MAC address`),
+			},
+		},
+	})
+}

--- a/internal/provider/device_data_source_test.go
+++ b/internal/provider/device_data_source_test.go
@@ -2,6 +2,7 @@ package provider
 
 import (
 	"fmt"
+	"os"
 	"regexp"
 	"testing"
 
@@ -92,11 +93,9 @@ func TestDeviceDataSourceAPIToModel(t *testing.T) {
 // resource first (which always works), then uses the data source to look up
 // the controller's own devices by listing them.
 func TestAccDeviceDataSource_byMAC(t *testing.T) {
-	// This test discovers a real device from the controller, so it uses a
-	// two-step approach: first list devices to find a MAC, then look it up.
-	// We use a config that references a data source with a known device.
-	// Since we can't predict which devices exist, we use a helper that
-	// finds the first adopted device.
+	if os.Getenv("TF_ACC") == "" {
+		t.Skip("TF_ACC not set")
+	}
 	resource.Test(t, resource.TestCase{
 		PreCheck: func() {
 			preCheck(t)
@@ -120,6 +119,9 @@ func TestAccDeviceDataSource_byMAC(t *testing.T) {
 }
 
 func TestAccDeviceDataSource_byName(t *testing.T) {
+	if os.Getenv("TF_ACC") == "" {
+		t.Skip("TF_ACC not set")
+	}
 	resource.Test(t, resource.TestCase{
 		PreCheck: func() {
 			preCheck(t)
@@ -142,6 +144,9 @@ func TestAccDeviceDataSource_byName(t *testing.T) {
 }
 
 func TestAccDeviceDataSource_withClientDevice(t *testing.T) {
+	if os.Getenv("TF_ACC") == "" {
+		t.Skip("TF_ACC not set")
+	}
 	mac := randomMAC()
 	resource.Test(t, resource.TestCase{
 		PreCheck: func() {

--- a/internal/provider/device_data_source_test.go
+++ b/internal/provider/device_data_source_test.go
@@ -96,12 +96,9 @@ func TestAccDeviceDataSource_byMAC(t *testing.T) {
 	if os.Getenv("TF_ACC") == "" {
 		t.Skip("TF_ACC not set")
 	}
+	preCheck(t)
+	requireAdoptedDevice(t)
 	resource.Test(t, resource.TestCase{
-		PreCheck: func() {
-			preCheck(t)
-			// Ensure at least one device exists
-			requireAdoptedDevice(t)
-		},
 		ProtoV6ProviderFactories: testAccProtoV6ProviderFactories,
 		Steps: []resource.TestStep{
 			{
@@ -122,11 +119,9 @@ func TestAccDeviceDataSource_byName(t *testing.T) {
 	if os.Getenv("TF_ACC") == "" {
 		t.Skip("TF_ACC not set")
 	}
+	preCheck(t)
+	requireAdoptedDevice(t)
 	resource.Test(t, resource.TestCase{
-		PreCheck: func() {
-			preCheck(t)
-			requireAdoptedDevice(t)
-		},
 		ProtoV6ProviderFactories: testAccProtoV6ProviderFactories,
 		Steps: []resource.TestStep{
 			{
@@ -147,12 +142,10 @@ func TestAccDeviceDataSource_withClientDevice(t *testing.T) {
 	if os.Getenv("TF_ACC") == "" {
 		t.Skip("TF_ACC not set")
 	}
+	preCheck(t)
+	requireAdoptedDevice(t)
 	mac := randomMAC()
 	resource.Test(t, resource.TestCase{
-		PreCheck: func() {
-			preCheck(t)
-			requireAdoptedDevice(t)
-		},
 		ProtoV6ProviderFactories: testAccProtoV6ProviderFactories,
 		Steps: []resource.TestStep{
 			{

--- a/internal/provider/provider.go
+++ b/internal/provider/provider.go
@@ -246,7 +246,9 @@ func (p *terrifiProvider) Resources(_ context.Context) []func() resource.Resourc
 // DataSources returns the list of data source types. Empty for now — we'll add
 // data sources (read-only lookups) as needed.
 func (p *terrifiProvider) DataSources(_ context.Context) []func() datasource.DataSource {
-	return []func() datasource.DataSource{}
+	return []func() datasource.DataSource{
+		NewDeviceDataSource,
+	}
 }
 
 // stringValueOrEnv returns the Terraform attribute value if non-empty, otherwise


### PR DESCRIPTION
## Summary

- Adds a `fixed_ap_mac` attribute to `terrifi_client_device` that lets users lock a client to a specific access point, matching the "Lock to Access Point" option in the UniFi UI
- Adds a `terrifi_device` data source for looking up network devices (APs, switches, gateways) by name or MAC, so users can reference device attributes without hardcoding
- Together, these enable the full workflow:
  ```terraform
  data "terrifi_device" "office_ap" {
    name = "Office AP"
  }

  resource "terrifi_client_device" "laptop" {
    mac          = "aa:bb:cc:dd:ee:ff"
    name         = "Work Laptop"
    fixed_ap_mac = data.terrifi_device.office_ap.mac
  }
  ```

Closes #113

## Test plan

- [x] Unit tests for `modelToAPI`, `apiToModel`, and `buildClientDeviceRequest` with `fixed_ap_mac`
- [x] HIL acceptance tests for `fixed_ap_mac` against real hardware:
  - `TestAccClientDevice_fixedApMAC` — basic create
  - `TestAccClientDevice_fixedApMACAddRemove` — add/remove toggle
  - `TestAccClientDevice_fixedApMACChange` — switch between APs
  - `TestAccClientDevice_fixedApMACIdempotent` — no-diff on reapply
  - `TestAccClientDevice_fixedApMACImport` — import state verify
- [x] Unit tests for `terrifi_device` data source `apiToModel`
- [x] HIL acceptance tests for `terrifi_device` data source:
  - `TestAccDeviceDataSource_byMAC` — lookup by MAC
  - `TestAccDeviceDataSource_byName` — lookup by name
  - `TestAccDeviceDataSource_withClientDevice` — end-to-end with `fixed_ap_mac`
  - Validation tests for invalid/missing input combinations

🤖 Generated with [Claude Code](https://claude.com/claude-code)