### PR TITLE
Fix hardcoded UniFi image version in CI docker save step

### DIFF
--- a/.github/workflows/ci-local.yaml
+++ b/.github/workflows/ci-local.yaml
@@ -74,7 +74,8 @@ jobs:
           docker compose -f docker-compose.yaml pull --quiet
           mkdir -p /tmp/docker-images
           docker save mongo:8.2 -o /tmp/docker-images/mongo.tar
-          docker save lscr.io/linuxserver/unifi-network-application:version-10.1.85 -o /tmp/docker-images/unifi.tar
+          UNIFI_IMAGE=$(grep 'unifi-network-application' docker-compose.yaml | awk '{print $2}')
+          docker save "$UNIFI_IMAGE" -o /tmp/docker-images/unifi.tar
       - name: Acceptance tests (Docker)
         timeout-minutes: 10
         run: task test:acc

--- a/.github/workflows/ci-local.yaml
+++ b/.github/workflows/ci-local.yaml
@@ -73,7 +73,8 @@ jobs:
         run: |
           docker compose -f docker-compose.yaml pull --quiet
           mkdir -p /tmp/docker-images
-          docker save mongo:8.2 -o /tmp/docker-images/mongo.tar
+          MONGO_IMAGE=$(grep -m1 'image: mongo' docker-compose.yaml | awk '{print $2}')
+          docker save "$MONGO_IMAGE" -o /tmp/docker-images/mongo.tar
           UNIFI_IMAGE=$(grep 'unifi-network-application' docker-compose.yaml | awk '{print $2}')
           docker save "$UNIFI_IMAGE" -o /tmp/docker-images/unifi.tar
       - name: Acceptance tests (Docker)

--- a/.github/workflows/ci-local.yaml
+++ b/.github/workflows/ci-local.yaml
@@ -73,10 +73,10 @@ jobs:
         run: |
           docker compose -f docker-compose.yaml pull --quiet
           mkdir -p /tmp/docker-images
-          MONGO_IMAGE=$(grep -m1 'image: mongo' docker-compose.yaml | awk '{print $2}')
-          docker save "$MONGO_IMAGE" -o /tmp/docker-images/mongo.tar
-          UNIFI_IMAGE=$(grep 'unifi-network-application' docker-compose.yaml | awk '{print $2}')
-          docker save "$UNIFI_IMAGE" -o /tmp/docker-images/unifi.tar
+          docker compose -f docker-compose.yaml config --images | while read -r img; do
+            name=$(echo "$img" | tr '/.:' '___')
+            docker save "$img" -o "/tmp/docker-images/${name}.tar"
+          done
       - name: Acceptance tests (Docker)
         timeout-minutes: 10
         run: task test:acc


### PR DESCRIPTION
## Summary

- The `Pull Docker images` step in `ci-local.yaml` had image versions hardcoded in `docker save` commands, causing failures whenever Dependabot bumped versions in `docker-compose.yaml`.
- Replaced all per-image `docker save` calls with a loop over `docker compose config --images`, so the step automatically handles any images declared in `docker-compose.yaml` with no future maintenance needed.

## Test plan

- [x] CI passes on this PR
- [x] After merge, trigger `@dependabot rebase` on PR #116 to confirm it also passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)