### PR TITLE
Add CUSTOM connection_state_type and icmp/icmpv6 protocol values

### DIFF
--- a/docs/resources/firewall_policy.md
+++ b/docs/resources/firewall_policy.md
@@ -141,8 +141,8 @@ resource "terrifi_firewall_policy" "weekday_block" {
 - `description` (String) — A description of the firewall policy.
 - `enabled` (Boolean) — Whether the policy is enabled. Default: `true`.
 - `ip_version` (String) — IP version to match. Valid values: `BOTH`, `IPV4`, `IPV6`. Default: `BOTH`.
-- `protocol` (String) — Protocol to match. Valid values: `all`, `tcp`, `udp`, `tcp_udp`. Default: `all`.
-- `connection_state_type` (String) — Connection state type. Valid values: `ALL`, `RESPOND_ONLY`. Default: `ALL`.
+- `protocol` (String) — Protocol to match. Valid values: `all`, `tcp`, `udp`, `tcp_udp`, `icmp`, `icmpv6`. Default: `all`.
+- `connection_state_type` (String) — Connection state type. Valid values: `ALL`, `RESPOND_ONLY`, `CUSTOM`. When set to `CUSTOM`, specify individual states via `connection_states`. Default: `ALL`.
 - `connection_states` (Set of String) — Connection states to match (e.g. `NEW`, `ESTABLISHED`, `RELATED`, `INVALID`).
 - `match_ipsec` (Boolean) — Whether to match IPsec traffic.
 - `logging` (Boolean) — Whether to enable syslog logging for matched traffic.

--- a/internal/generate/generate_test.go
+++ b/internal/generate/generate_test.go
@@ -565,6 +565,62 @@ func TestFirewallPolicyBlocks_alwaysScheduleOmitted(t *testing.T) {
 	assert.Empty(t, blocks[0].Blocks)
 }
 
+func TestFirewallPolicyBlocks_customConnectionStateType(t *testing.T) {
+	policies := []*unifi.FirewallPolicy{
+		{
+			ID:                  "pol1",
+			Name:                "Block Invalid Traffic",
+			Enabled:             true,
+			Action:              "BLOCK",
+			ConnectionStateType: "CUSTOM",
+			ConnectionStates:    []string{"INVALID"},
+			Source: &unifi.FirewallPolicySource{
+				ZoneID:         "zone1",
+				MatchingTarget: "ANY",
+			},
+			Destination: &unifi.FirewallPolicyDestination{
+				ZoneID:         "zone2",
+				MatchingTarget: "ANY",
+			},
+		},
+	}
+
+	blocks := FirewallPolicyBlocks(policies)
+	require.Len(t, blocks, 1)
+
+	attrs := attrMapFromBlock(blocks[0])
+	assert.Equal(t, `"CUSTOM"`, attrs["connection_state_type"])
+	assert.Equal(t, `["INVALID"]`, attrs["connection_states"])
+}
+
+func TestFirewallPolicyBlocks_icmpv6Protocol(t *testing.T) {
+	policies := []*unifi.FirewallPolicy{
+		{
+			ID:        "pol1",
+			Name:      "Allow Neighbor Solicitations",
+			Enabled:   true,
+			Action:    "ALLOW",
+			IPVersion: "IPV6",
+			Protocol:  "icmpv6",
+			Source: &unifi.FirewallPolicySource{
+				ZoneID:         "zone1",
+				MatchingTarget: "ANY",
+			},
+			Destination: &unifi.FirewallPolicyDestination{
+				ZoneID:         "zone2",
+				MatchingTarget: "ANY",
+			},
+		},
+	}
+
+	blocks := FirewallPolicyBlocks(policies)
+	require.Len(t, blocks, 1)
+
+	attrs := attrMapFromBlock(blocks[0])
+	assert.Equal(t, `"icmpv6"`, attrs["protocol"])
+	assert.Equal(t, `"IPV6"`, attrs["ip_version"])
+}
+
 // ---------------------------------------------------------------------------
 // NetworkBlocks
 // ---------------------------------------------------------------------------

--- a/internal/provider/firewall_policy_resource.go
+++ b/internal/provider/firewall_policy_resource.go
@@ -222,22 +222,22 @@ func (r *firewallPolicyResource) Schema(
 			},
 
 			"protocol": schema.StringAttribute{
-				MarkdownDescription: "Protocol to match. Valid values: `all`, `tcp`, `udp`, `tcp_udp`. Default: `all`.",
+				MarkdownDescription: "Protocol to match. Valid values: `all`, `tcp`, `udp`, `tcp_udp`, `icmp`, `icmpv6`. Default: `all`.",
 				Optional:            true,
 				Computed:            true,
 				Default:             stringdefault.StaticString("all"),
 				Validators: []validator.String{
-					stringvalidator.OneOf("all", "tcp", "udp", "tcp_udp"),
+					stringvalidator.OneOf("all", "tcp", "udp", "tcp_udp", "icmp", "icmpv6"),
 				},
 			},
 
 			"connection_state_type": schema.StringAttribute{
-				MarkdownDescription: "Connection state type. Valid values: `ALL`, `RESPOND_ONLY`. Default: `ALL`.",
+				MarkdownDescription: "Connection state type. Valid values: `ALL`, `RESPOND_ONLY`, `CUSTOM`. When set to `CUSTOM`, specify individual states via `connection_states`. Default: `ALL`.",
 				Optional:            true,
 				Computed:            true,
 				Default:             stringdefault.StaticString("ALL"),
 				Validators: []validator.String{
-					stringvalidator.OneOf("ALL", "RESPOND_ONLY"),
+					stringvalidator.OneOf("ALL", "RESPOND_ONLY", "CUSTOM"),
 				},
 			},
 

--- a/internal/provider/firewall_policy_resource.go
+++ b/internal/provider/firewall_policy_resource.go
@@ -663,7 +663,10 @@ func (r *firewallPolicyResource) apiToModel(policy *unifi.FirewallPolicy, m *fir
 		m.ConnectionStateType = types.StringValue("ALL")
 	}
 
-	if len(policy.ConnectionStates) > 0 {
+	// Only propagate connection_states when the type is CUSTOM or RESPOND_ONLY.
+	// When ALL, the API may still return stale states from a prior config, so
+	// we discard them to avoid spurious diffs.
+	if m.ConnectionStateType.ValueString() != "ALL" && len(policy.ConnectionStates) > 0 {
 		vals := make([]attr.Value, len(policy.ConnectionStates))
 		for i, s := range policy.ConnectionStates {
 			vals[i] = types.StringValue(s)

--- a/internal/provider/firewall_policy_resource_test.go
+++ b/internal/provider/firewall_policy_resource_test.go
@@ -2568,6 +2568,226 @@ resource "terrifi_firewall_policy" "test" {
 	})
 }
 
+func TestAccFirewallPolicy_customConnectionStateType(t *testing.T) {
+	zone1Name := fmt.Sprintf("tfacc-pol-cst-z1-%s", randomSuffix())
+	zone2Name := fmt.Sprintf("tfacc-pol-cst-z2-%s", randomSuffix())
+	policyName := fmt.Sprintf("tfacc-pol-custom-%s", randomSuffix())
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:                 func() { preCheck(t); requireHardware(t) },
+		ProtoV6ProviderFactories: testAccProtoV6ProviderFactories,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccFirewallPolicyZonesConfig(zone1Name, zone2Name) + fmt.Sprintf(`
+resource "terrifi_firewall_policy" "test" {
+  name                  = %q
+  action                = "BLOCK"
+  connection_state_type = "CUSTOM"
+  connection_states     = ["INVALID"]
+
+  source {
+    zone_id = terrifi_firewall_zone.zone1.id
+  }
+
+  destination {
+    zone_id = terrifi_firewall_zone.zone2.id
+  }
+}
+`, policyName),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr("terrifi_firewall_policy.test", "connection_state_type", "CUSTOM"),
+					resource.TestCheckResourceAttr("terrifi_firewall_policy.test", "connection_states.#", "1"),
+					resource.TestCheckTypeSetElemAttr("terrifi_firewall_policy.test", "connection_states.*", "INVALID"),
+				),
+			},
+		},
+	})
+}
+
+func TestAccFirewallPolicy_customConnectionStateTypeMultiple(t *testing.T) {
+	zone1Name := fmt.Sprintf("tfacc-pol-csm-z1-%s", randomSuffix())
+	zone2Name := fmt.Sprintf("tfacc-pol-csm-z2-%s", randomSuffix())
+	policyName := fmt.Sprintf("tfacc-pol-custm-%s", randomSuffix())
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:                 func() { preCheck(t); requireHardware(t) },
+		ProtoV6ProviderFactories: testAccProtoV6ProviderFactories,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccFirewallPolicyZonesConfig(zone1Name, zone2Name) + fmt.Sprintf(`
+resource "terrifi_firewall_policy" "test" {
+  name                  = %q
+  action                = "ALLOW"
+  connection_state_type = "CUSTOM"
+  connection_states     = ["NEW", "ESTABLISHED", "RELATED"]
+
+  source {
+    zone_id = terrifi_firewall_zone.zone1.id
+  }
+
+  destination {
+    zone_id = terrifi_firewall_zone.zone2.id
+  }
+}
+`, policyName),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr("terrifi_firewall_policy.test", "connection_state_type", "CUSTOM"),
+					resource.TestCheckResourceAttr("terrifi_firewall_policy.test", "connection_states.#", "3"),
+					resource.TestCheckTypeSetElemAttr("terrifi_firewall_policy.test", "connection_states.*", "NEW"),
+					resource.TestCheckTypeSetElemAttr("terrifi_firewall_policy.test", "connection_states.*", "ESTABLISHED"),
+					resource.TestCheckTypeSetElemAttr("terrifi_firewall_policy.test", "connection_states.*", "RELATED"),
+				),
+			},
+		},
+	})
+}
+
+func TestAccFirewallPolicy_icmpv6Protocol(t *testing.T) {
+	zone1Name := fmt.Sprintf("tfacc-pol-icmp6-z1-%s", randomSuffix())
+	zone2Name := fmt.Sprintf("tfacc-pol-icmp6-z2-%s", randomSuffix())
+	policyName := fmt.Sprintf("tfacc-pol-icmpv6-%s", randomSuffix())
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:                 func() { preCheck(t); requireHardware(t) },
+		ProtoV6ProviderFactories: testAccProtoV6ProviderFactories,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccFirewallPolicyZonesConfig(zone1Name, zone2Name) + fmt.Sprintf(`
+resource "terrifi_firewall_policy" "test" {
+  name       = %q
+  action     = "ALLOW"
+  ip_version = "IPV6"
+  protocol   = "icmpv6"
+
+  source {
+    zone_id = terrifi_firewall_zone.zone1.id
+  }
+
+  destination {
+    zone_id = terrifi_firewall_zone.zone2.id
+  }
+}
+`, policyName),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr("terrifi_firewall_policy.test", "protocol", "icmpv6"),
+					resource.TestCheckResourceAttr("terrifi_firewall_policy.test", "ip_version", "IPV6"),
+				),
+			},
+		},
+	})
+}
+
+func TestAccFirewallPolicy_icmpProtocol(t *testing.T) {
+	zone1Name := fmt.Sprintf("tfacc-pol-icmp-z1-%s", randomSuffix())
+	zone2Name := fmt.Sprintf("tfacc-pol-icmp-z2-%s", randomSuffix())
+	policyName := fmt.Sprintf("tfacc-pol-icmp-%s", randomSuffix())
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:                 func() { preCheck(t); requireHardware(t) },
+		ProtoV6ProviderFactories: testAccProtoV6ProviderFactories,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccFirewallPolicyZonesConfig(zone1Name, zone2Name) + fmt.Sprintf(`
+resource "terrifi_firewall_policy" "test" {
+  name       = %q
+  action     = "ALLOW"
+  ip_version = "IPV4"
+  protocol   = "icmp"
+
+  source {
+    zone_id = terrifi_firewall_zone.zone1.id
+  }
+
+  destination {
+    zone_id = terrifi_firewall_zone.zone2.id
+  }
+}
+`, policyName),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr("terrifi_firewall_policy.test", "protocol", "icmp"),
+					resource.TestCheckResourceAttr("terrifi_firewall_policy.test", "ip_version", "IPV4"),
+				),
+			},
+		},
+	})
+}
+
+func TestAccFirewallPolicy_updateConnectionStateType(t *testing.T) {
+	zone1Name := fmt.Sprintf("tfacc-pol-ucst-z1-%s", randomSuffix())
+	zone2Name := fmt.Sprintf("tfacc-pol-ucst-z2-%s", randomSuffix())
+	policyName := fmt.Sprintf("tfacc-pol-ucst-%s", randomSuffix())
+
+	zonesConfig := testAccFirewallPolicyZonesConfig(zone1Name, zone2Name)
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:                 func() { preCheck(t); requireHardware(t) },
+		ProtoV6ProviderFactories: testAccProtoV6ProviderFactories,
+		Steps: []resource.TestStep{
+			{
+				Config: zonesConfig + fmt.Sprintf(`
+resource "terrifi_firewall_policy" "test" {
+  name   = %q
+  action = "BLOCK"
+
+  source {
+    zone_id = terrifi_firewall_zone.zone1.id
+  }
+
+  destination {
+    zone_id = terrifi_firewall_zone.zone2.id
+  }
+}
+`, policyName),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr("terrifi_firewall_policy.test", "connection_state_type", "ALL"),
+				),
+			},
+			{
+				Config: zonesConfig + fmt.Sprintf(`
+resource "terrifi_firewall_policy" "test" {
+  name                  = %q
+  action                = "BLOCK"
+  connection_state_type = "CUSTOM"
+  connection_states     = ["INVALID"]
+
+  source {
+    zone_id = terrifi_firewall_zone.zone1.id
+  }
+
+  destination {
+    zone_id = terrifi_firewall_zone.zone2.id
+  }
+}
+`, policyName),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr("terrifi_firewall_policy.test", "connection_state_type", "CUSTOM"),
+					resource.TestCheckResourceAttr("terrifi_firewall_policy.test", "connection_states.#", "1"),
+					resource.TestCheckTypeSetElemAttr("terrifi_firewall_policy.test", "connection_states.*", "INVALID"),
+				),
+			},
+			{
+				Config: zonesConfig + fmt.Sprintf(`
+resource "terrifi_firewall_policy" "test" {
+  name   = %q
+  action = "BLOCK"
+
+  source {
+    zone_id = terrifi_firewall_zone.zone1.id
+  }
+
+  destination {
+    zone_id = terrifi_firewall_zone.zone2.id
+  }
+}
+`, policyName),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr("terrifi_firewall_policy.test", "connection_state_type", "ALL"),
+				),
+			},
+		},
+	})
+}
+
 // ---------------------------------------------------------------------------
 // Test helpers
 // ---------------------------------------------------------------------------

--- a/internal/provider/firewall_policy_resource_test.go
+++ b/internal/provider/firewall_policy_resource_test.go
@@ -313,6 +313,108 @@ func TestFirewallPolicyModelToAPI(t *testing.T) {
 		assert.ElementsMatch(t, []string{"NEW", "ESTABLISHED"}, policy.ConnectionStates)
 	})
 
+	t.Run("CUSTOM connection state type with explicit states", func(t *testing.T) {
+		srcObj := types.ObjectValueMust(endpointAttrTypes, map[string]attr.Value{
+			"zone_id":              types.StringValue("zone-src"),
+			"ips":                  types.SetNull(types.StringType),
+			"mac_addresses":        types.SetNull(types.StringType),
+			"network_ids":          types.SetNull(types.StringType),
+			"device_ids":           types.SetNull(types.StringType),
+			"port_matching_type":   types.StringValue("ANY"),
+			"port":                 types.Int64Null(),
+			"port_group_id":        types.StringNull(),
+			"match_opposite_ports": types.BoolNull(),
+			"match_opposite_ips":   types.BoolNull(),
+		})
+		dstObj := types.ObjectValueMust(endpointAttrTypes, map[string]attr.Value{
+			"zone_id":              types.StringValue("zone-dst"),
+			"ips":                  types.SetNull(types.StringType),
+			"mac_addresses":        types.SetNull(types.StringType),
+			"network_ids":          types.SetNull(types.StringType),
+			"device_ids":           types.SetNull(types.StringType),
+			"port_matching_type":   types.StringValue("ANY"),
+			"port":                 types.Int64Null(),
+			"port_group_id":        types.StringNull(),
+			"match_opposite_ports": types.BoolNull(),
+			"match_opposite_ips":   types.BoolNull(),
+		})
+
+		model := &firewallPolicyResourceModel{
+			Name:                types.StringValue("Block Invalid Traffic"),
+			Action:              types.StringValue("BLOCK"),
+			Enabled:             types.BoolValue(true),
+			IPVersion:           types.StringValue("BOTH"),
+			Protocol:            types.StringValue("all"),
+			ConnectionStateType: types.StringValue("CUSTOM"),
+			ConnectionStates: types.SetValueMust(types.StringType, []attr.Value{
+				types.StringValue("INVALID"),
+			}),
+			Description:        types.StringNull(),
+			MatchIPSec:         types.BoolNull(),
+			Logging:            types.BoolNull(),
+			CreateAllowRespond: types.BoolNull(),
+			Index:              types.Int64Null(),
+			Source:             srcObj,
+			Destination:        dstObj,
+			Schedule:           types.ObjectNull(scheduleAttrTypes),
+		}
+
+		policy := r.modelToAPI(ctx, model)
+
+		assert.Equal(t, "CUSTOM", policy.ConnectionStateType)
+		assert.ElementsMatch(t, []string{"INVALID"}, policy.ConnectionStates)
+	})
+
+	t.Run("icmpv6 protocol", func(t *testing.T) {
+		srcObj := types.ObjectValueMust(endpointAttrTypes, map[string]attr.Value{
+			"zone_id":              types.StringValue("zone-src"),
+			"ips":                  types.SetNull(types.StringType),
+			"mac_addresses":        types.SetNull(types.StringType),
+			"network_ids":          types.SetNull(types.StringType),
+			"device_ids":           types.SetNull(types.StringType),
+			"port_matching_type":   types.StringValue("ANY"),
+			"port":                 types.Int64Null(),
+			"port_group_id":        types.StringNull(),
+			"match_opposite_ports": types.BoolNull(),
+			"match_opposite_ips":   types.BoolNull(),
+		})
+		dstObj := types.ObjectValueMust(endpointAttrTypes, map[string]attr.Value{
+			"zone_id":              types.StringValue("zone-dst"),
+			"ips":                  types.SetNull(types.StringType),
+			"mac_addresses":        types.SetNull(types.StringType),
+			"network_ids":          types.SetNull(types.StringType),
+			"device_ids":           types.SetNull(types.StringType),
+			"port_matching_type":   types.StringValue("ANY"),
+			"port":                 types.Int64Null(),
+			"port_group_id":        types.StringNull(),
+			"match_opposite_ports": types.BoolNull(),
+			"match_opposite_ips":   types.BoolNull(),
+		})
+
+		model := &firewallPolicyResourceModel{
+			Name:                types.StringValue("Allow Neighbor Solicitations"),
+			Action:              types.StringValue("ALLOW"),
+			Enabled:             types.BoolValue(true),
+			IPVersion:           types.StringValue("IPV6"),
+			Protocol:            types.StringValue("icmpv6"),
+			ConnectionStateType: types.StringValue("ALL"),
+			ConnectionStates:    types.SetNull(types.StringType),
+			Description:         types.StringNull(),
+			MatchIPSec:          types.BoolNull(),
+			Logging:             types.BoolNull(),
+			CreateAllowRespond:  types.BoolNull(),
+			Index:               types.Int64Null(),
+			Source:              srcObj,
+			Destination:         dstObj,
+			Schedule:            types.ObjectNull(scheduleAttrTypes),
+		}
+
+		policy := r.modelToAPI(ctx, model)
+
+		assert.Equal(t, "icmpv6", policy.Protocol)
+		assert.Equal(t, "IPV6", policy.IPVersion)
+	})
+
 	t.Run("with MAC addresses", func(t *testing.T) {
 		srcObj := types.ObjectValueMust(endpointAttrTypes, map[string]attr.Value{
 			"zone_id": types.StringValue("zone-src"),
@@ -743,6 +845,82 @@ func TestFirewallPolicyAPIToModel(t *testing.T) {
 		assert.Equal(t, "BOTH", model.IPVersion.ValueString())
 		assert.Equal(t, "all", model.Protocol.ValueString())
 		assert.Equal(t, "ALL", model.ConnectionStateType.ValueString())
+	})
+
+	t.Run("CUSTOM connection state type round-trip", func(t *testing.T) {
+		policy := &unifi.FirewallPolicy{
+			ID:                  "pol-020",
+			Name:                "Block Invalid Traffic",
+			Action:              "BLOCK",
+			Enabled:             true,
+			ConnectionStateType: "CUSTOM",
+			ConnectionStates:    []string{"INVALID"},
+			Source: &unifi.FirewallPolicySource{
+				ZoneID:         "zone-src",
+				MatchingTarget: "ANY",
+			},
+			Destination: &unifi.FirewallPolicyDestination{
+				ZoneID:         "zone-dst",
+				MatchingTarget: "ANY",
+			},
+		}
+
+		var model firewallPolicyResourceModel
+		r.apiToModel(policy, &model, "default")
+
+		assert.Equal(t, "CUSTOM", model.ConnectionStateType.ValueString())
+		assert.False(t, model.ConnectionStates.IsNull())
+		var states []string
+		model.ConnectionStates.ElementsAs(context.Background(), &states, false)
+		assert.ElementsMatch(t, []string{"INVALID"}, states)
+	})
+
+	t.Run("icmpv6 protocol round-trip", func(t *testing.T) {
+		policy := &unifi.FirewallPolicy{
+			ID:        "pol-021",
+			Name:      "Allow Neighbor Solicitations",
+			Action:    "ALLOW",
+			Enabled:   true,
+			IPVersion: "IPV6",
+			Protocol:  "icmpv6",
+			Source: &unifi.FirewallPolicySource{
+				ZoneID:         "zone-src",
+				MatchingTarget: "ANY",
+			},
+			Destination: &unifi.FirewallPolicyDestination{
+				ZoneID:         "zone-dst",
+				MatchingTarget: "ANY",
+			},
+		}
+
+		var model firewallPolicyResourceModel
+		r.apiToModel(policy, &model, "default")
+
+		assert.Equal(t, "icmpv6", model.Protocol.ValueString())
+		assert.Equal(t, "IPV6", model.IPVersion.ValueString())
+	})
+
+	t.Run("icmp protocol round-trip", func(t *testing.T) {
+		policy := &unifi.FirewallPolicy{
+			ID:       "pol-022",
+			Name:     "ICMP Rule",
+			Action:   "ALLOW",
+			Enabled:  true,
+			Protocol: "icmp",
+			Source: &unifi.FirewallPolicySource{
+				ZoneID:         "zone-src",
+				MatchingTarget: "ANY",
+			},
+			Destination: &unifi.FirewallPolicyDestination{
+				ZoneID:         "zone-dst",
+				MatchingTarget: "ANY",
+			},
+		}
+
+		var model firewallPolicyResourceModel
+		r.apiToModel(policy, &model, "default")
+
+		assert.Equal(t, "icmp", model.Protocol.ValueString())
 	})
 
 	t.Run("with schedule", func(t *testing.T) {

--- a/internal/provider/firewall_policy_resource_test.go
+++ b/internal/provider/firewall_policy_resource_test.go
@@ -847,6 +847,33 @@ func TestFirewallPolicyAPIToModel(t *testing.T) {
 		assert.Equal(t, "ALL", model.ConnectionStateType.ValueString())
 	})
 
+	t.Run("ALL connection state type discards stale states from API", func(t *testing.T) {
+		// API may return connection_states even when type is ALL (stale from prior CUSTOM config).
+		// Provider must discard them to avoid spurious diffs.
+		policy := &unifi.FirewallPolicy{
+			ID:                  "pol-019",
+			Name:                "Block All States",
+			Action:              "BLOCK",
+			Enabled:             true,
+			ConnectionStateType: "ALL",
+			ConnectionStates:    []string{"INVALID"}, // stale, should be discarded
+			Source: &unifi.FirewallPolicySource{
+				ZoneID:         "zone-src",
+				MatchingTarget: "ANY",
+			},
+			Destination: &unifi.FirewallPolicyDestination{
+				ZoneID:         "zone-dst",
+				MatchingTarget: "ANY",
+			},
+		}
+
+		var model firewallPolicyResourceModel
+		r.apiToModel(policy, &model, "default")
+
+		assert.Equal(t, "ALL", model.ConnectionStateType.ValueString())
+		assert.True(t, model.ConnectionStates.IsNull())
+	})
+
 	t.Run("CUSTOM connection state type round-trip", func(t *testing.T) {
 		policy := &unifi.FirewallPolicy{
 			ID:                  "pol-020",


### PR DESCRIPTION
## Summary
- Add `"CUSTOM"` to `connection_state_type` schema validator (API returns this for "Block Invalid Traffic" default policies)
- Add `"icmp"` and `"icmpv6"` to `protocol` schema validator (API returns these for ICMP/IPv6 neighbor solicitation policies)
- No changes to generate-imports needed — it already passes through values correctly

Fixes #118

## Test plan
- [x] Unit tests for ModelToAPI with `CUSTOM` connection state type
- [x] Unit tests for ModelToAPI with `icmpv6` protocol
- [x] Unit tests for APIToModel round-trips (`CUSTOM`, `icmpv6`, `icmp`)
- [x] Generate tests for `CUSTOM` and `icmpv6` HCL output
- [ ] Acceptance tests against controller with default "Block Invalid Traffic" policies

🤖 Generated with [Claude Code](https://claude.com/claude-code)