### PR TITLE
Skip predefined firewall policies in generate-imports

### DIFF
--- a/internal/generate/firewall_policy.go
+++ b/internal/generate/firewall_policy.go
@@ -8,6 +8,9 @@ import (
 func FirewallPolicyBlocks(policies []*unifi.FirewallPolicy) []ResourceBlock {
 	blocks := make([]ResourceBlock, 0, len(policies))
 	for _, p := range policies {
+		if p.Predefined {
+			continue
+		}
 		block := ResourceBlock{
 			ResourceType: "terrifi_firewall_policy",
 			ResourceName: ToTerraformName(p.Name),

--- a/internal/generate/generate_test.go
+++ b/internal/generate/generate_test.go
@@ -565,6 +565,28 @@ func TestFirewallPolicyBlocks_alwaysScheduleOmitted(t *testing.T) {
 	assert.Empty(t, blocks[0].Blocks)
 }
 
+func TestFirewallPolicyBlocks_predefinedSkipped(t *testing.T) {
+	policies := []*unifi.FirewallPolicy{
+		{
+			ID:         "pol1",
+			Name:       "Block Invalid Traffic",
+			Enabled:    true,
+			Action:     "BLOCK",
+			Predefined: true,
+		},
+		{
+			ID:      "pol2",
+			Name:    "User Policy",
+			Enabled: true,
+			Action:  "ALLOW",
+		},
+	}
+
+	blocks := FirewallPolicyBlocks(policies)
+	require.Len(t, blocks, 1)
+	assert.Equal(t, "user_policy", blocks[0].ResourceName)
+}
+
 func TestFirewallPolicyBlocks_customConnectionStateType(t *testing.T) {
 	policies := []*unifi.FirewallPolicy{
 		{


### PR DESCRIPTION
## Summary
- Skip predefined (system-managed) firewall policies in `FirewallPolicyBlocks`, consistent with `FirewallPolicyOrderBlocks` which already skips them

## Background
Predefined policies like "Block Invalid Traffic" are controller-owned and cannot be faithfully recreated via the API — they have attribute combinations (e.g. `create_allow_respond = true` + `CUSTOM` connection states) that the API rejects on POST with `FirewallPolicyCreateRespondTrafficPolicyNotAllowed`. Discovered after #120 was merged when a user tried to apply the generated HCL.

## Test plan
- [x] Unit test: predefined policies skipped, user policies included

🤖 Generated with [Claude Code](https://claude.com/claude-code)