### PR TITLE
Validate create_allow_respond against external zone destination

### DIFF
--- a/docs/resources/firewall_policy.md
+++ b/docs/resources/firewall_policy.md
@@ -146,7 +146,7 @@ resource "terrifi_firewall_policy" "weekday_block" {
 - `connection_states` (Set of String) — Connection states to match (e.g. `NEW`, `ESTABLISHED`, `RELATED`, `INVALID`).
 - `match_ipsec` (Boolean) — Whether to match IPsec traffic.
 - `logging` (Boolean) — Whether to enable syslog logging for matched traffic.
-- `create_allow_respond` (Boolean) — Whether to create a corresponding allow-respond rule.
+- `create_allow_respond` (Boolean) — Whether to create a corresponding allow-respond rule. Not supported when the destination zone is the external zone — UniFi handles WAN return traffic at the stateful firewall level automatically. Setting this to `true` with an external zone destination will produce an error at plan time.
 - `schedule` (Block) — Schedule configuration. See [Schedule](#schedule) below.
 - `site` (String) — The site. Defaults to the provider site. Changing this forces a new resource.
 

--- a/internal/provider/firewall_policy_resource.go
+++ b/internal/provider/firewall_policy_resource.go
@@ -23,6 +23,7 @@ import (
 var (
 	_ resource.Resource                = &firewallPolicyResource{}
 	_ resource.ResourceWithImportState = &firewallPolicyResource{}
+	_ resource.ResourceWithModifyPlan  = &firewallPolicyResource{}
 )
 
 func NewFirewallPolicyResource() resource.Resource {
@@ -258,7 +259,7 @@ func (r *firewallPolicyResource) Schema(
 			},
 
 			"create_allow_respond": schema.BoolAttribute{
-				MarkdownDescription: "Whether to automatically create a corresponding allow-respond rule.",
+				MarkdownDescription: "Whether to automatically create a corresponding allow-respond rule. Not supported when the destination zone is the external zone — UniFi handles WAN return traffic at the stateful firewall level automatically.",
 				Optional:            true,
 			},
 
@@ -452,6 +453,56 @@ func (r *firewallPolicyResource) ImportState(
 	}
 
 	resource.ImportStatePassthroughID(ctx, path.Root("id"), req, resp)
+}
+
+func (r *firewallPolicyResource) ModifyPlan(
+	ctx context.Context,
+	req resource.ModifyPlanRequest,
+	resp *resource.ModifyPlanResponse,
+) {
+	// Skip if provider not yet configured, or during destroy (plan is null).
+	if r.client == nil || req.Plan.Raw.IsNull() {
+		return
+	}
+
+	var plan firewallPolicyResourceModel
+	resp.Diagnostics.Append(req.Plan.Get(ctx, &plan)...)
+	if resp.Diagnostics.HasError() {
+		return
+	}
+
+	// Only validate when create_allow_respond is explicitly true.
+	if plan.CreateAllowRespond.IsNull() || plan.CreateAllowRespond.IsUnknown() || !plan.CreateAllowRespond.ValueBool() {
+		return
+	}
+
+	// Skip if destination or its zone_id is unknown (e.g. zone not yet created).
+	if plan.Destination.IsNull() || plan.Destination.IsUnknown() {
+		return
+	}
+
+	var dst firewallPolicyEndpointModel
+	plan.Destination.As(ctx, &dst, basetypes.ObjectAsOptions{})
+
+	if dst.ZoneID.IsNull() || dst.ZoneID.IsUnknown() {
+		return
+	}
+
+	site := r.client.SiteOrDefault(plan.Site)
+	zone, err := r.client.GetFirewallZone(ctx, site, dst.ZoneID.ValueString())
+	if err != nil {
+		// Zone lookup failed — skip provider-side validation and let the API respond.
+		return
+	}
+
+	if zone.ZoneKey == "external" {
+		resp.Diagnostics.AddAttributeError(
+			path.Root("create_allow_respond"),
+			"Unsupported Attribute Configuration",
+			"create_allow_respond is not supported for policies targeting the external zone. "+
+				"UniFi handles WAN return traffic at the stateful firewall level automatically.",
+		)
+	}
 }
 
 // ---------------------------------------------------------------------------

--- a/internal/provider/firewall_policy_resource_test.go
+++ b/internal/provider/firewall_policy_resource_test.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"fmt"
 	"net/http"
+	"os"
 	"regexp"
 	"testing"
 
@@ -2818,7 +2819,12 @@ resource "terrifi_firewall_policy" "test" {
 }
 
 func TestAccFirewallPolicy_createAllowRespondExternalZone(t *testing.T) {
-	// The external zone is predefined on real controllers only.
+	// The external zone is predefined on real controllers only. Guard TF_ACC
+	// first so the framework's own skip fires when running as unit tests, then
+	// validate env vars and hardware requirement before the API lookup.
+	if os.Getenv("TF_ACC") == "" {
+		t.Skip("acceptance tests skipped unless env 'TF_ACC' set")
+	}
 	preCheck(t)
 	requireHardware(t)
 

--- a/internal/provider/firewall_policy_resource_test.go
+++ b/internal/provider/firewall_policy_resource_test.go
@@ -2857,7 +2857,7 @@ resource "terrifi_firewall_policy" "test" {
   }
 }
 `, srcZoneName, policyName, externalZoneID),
-				ExpectError: regexp.MustCompile(`create_allow_respond is not supported for policies targeting the external zone`),
+				ExpectError: regexp.MustCompile(`create_allow_respond is not supported`),
 			},
 			{
 				// Same config without create_allow_respond succeeds.

--- a/internal/provider/firewall_policy_resource_test.go
+++ b/internal/provider/firewall_policy_resource_test.go
@@ -3,6 +3,8 @@ package provider
 import (
 	"context"
 	"fmt"
+	"net/http"
+	"regexp"
 	"testing"
 
 	"github.com/hashicorp/terraform-plugin-framework/attr"
@@ -2815,9 +2817,136 @@ resource "terrifi_firewall_policy" "test" {
 	})
 }
 
+func TestAccFirewallPolicy_createAllowRespondExternalZone(t *testing.T) {
+	// The external zone is predefined on real controllers only.
+	preCheck(t)
+	requireHardware(t)
+
+	externalZoneID := getExternalZoneID(t)
+	srcZoneName := fmt.Sprintf("tfacc-pol-car-src-%s", randomSuffix())
+	policyName := fmt.Sprintf("tfacc-pol-car-ext-%s", randomSuffix())
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:                 func() { preCheck(t); requireHardware(t) },
+		ProtoV6ProviderFactories: testAccProtoV6ProviderFactories,
+		Steps: []resource.TestStep{
+			{
+				// create_allow_respond = true + external zone destination → plan-time error.
+				Config: fmt.Sprintf(`
+resource "terrifi_firewall_zone" "source" {
+  name = %q
+}
+
+resource "terrifi_firewall_policy" "test" {
+  name                 = %q
+  action               = "ALLOW"
+  create_allow_respond = true
+
+  source {
+    zone_id = terrifi_firewall_zone.source.id
+  }
+
+  destination {
+    zone_id = %q
+  }
+}
+`, srcZoneName, policyName, externalZoneID),
+				ExpectError: regexp.MustCompile(`create_allow_respond is not supported for policies targeting the external zone`),
+			},
+			{
+				// Same config without create_allow_respond succeeds.
+				Config: fmt.Sprintf(`
+resource "terrifi_firewall_zone" "source" {
+  name = %q
+}
+
+resource "terrifi_firewall_policy" "test" {
+  name   = %q
+  action = "ALLOW"
+
+  source {
+    zone_id = terrifi_firewall_zone.source.id
+  }
+
+  destination {
+    zone_id = %q
+  }
+}
+`, srcZoneName, policyName, externalZoneID),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr("terrifi_firewall_policy.test", "action", "ALLOW"),
+					resource.TestCheckNoResourceAttr("terrifi_firewall_policy.test", "create_allow_respond"),
+				),
+			},
+		},
+	})
+}
+
+func TestAccFirewallPolicy_createAllowRespondNonExternal(t *testing.T) {
+	zone1Name := fmt.Sprintf("tfacc-pol-car-z1-%s", randomSuffix())
+	zone2Name := fmt.Sprintf("tfacc-pol-car-z2-%s", randomSuffix())
+	policyName := fmt.Sprintf("tfacc-pol-car-%s", randomSuffix())
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:                 func() { preCheck(t); requireHardware(t) },
+		ProtoV6ProviderFactories: testAccProtoV6ProviderFactories,
+		Steps: []resource.TestStep{
+			{
+				// create_allow_respond = true + non-external destination → no error.
+				Config: testAccFirewallPolicyZonesConfig(zone1Name, zone2Name) + fmt.Sprintf(`
+resource "terrifi_firewall_policy" "test" {
+  name                 = %q
+  action               = "ALLOW"
+  create_allow_respond = true
+
+  source {
+    zone_id = terrifi_firewall_zone.zone1.id
+  }
+
+  destination {
+    zone_id = terrifi_firewall_zone.zone2.id
+  }
+}
+`, policyName),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr("terrifi_firewall_policy.test", "create_allow_respond", "true"),
+				),
+			},
+		},
+	})
+}
+
 // ---------------------------------------------------------------------------
 // Test helpers
 // ---------------------------------------------------------------------------
+
+// getExternalZoneID returns the ID of the predefined external (WAN) zone on the
+// connected controller. Fails the test if no such zone exists.
+func getExternalZoneID(t *testing.T) string {
+	t.Helper()
+	ctx := context.Background()
+	cfg := ClientConfigFromEnv()
+	client, err := NewClient(ctx, cfg)
+	if err != nil {
+		t.Fatalf("failed to create test client: %s", err)
+	}
+
+	var zones []unifi.FirewallZone
+	if err := client.doV2Request(ctx, http.MethodGet,
+		fmt.Sprintf("%s%s/v2/api/site/%s/firewall/zone", client.BaseURL, client.APIPath, client.Site),
+		struct{}{}, &zones,
+	); err != nil {
+		t.Fatalf("failed to list firewall zones: %s", err)
+	}
+
+	for _, z := range zones {
+		if z.ZoneKey == "external" {
+			return z.ID
+		}
+	}
+	t.Fatal("no external zone found on this controller — is zone-based firewall enabled?")
+	return ""
+}
 
 func testAccFirewallPolicyZonesConfig(zone1Name, zone2Name string) string {
 	return fmt.Sprintf(`


### PR DESCRIPTION
## Summary

Fixes #107.

- Adds `ModifyPlan` to `firewallPolicyResource` that looks up the destination zone via the API and returns a clear diagnostic error when `create_allow_respond = true` targets the external (WAN) zone — surfacing the issue at plan time instead of forwarding an opaque `api.err.FirewallPolicyCreateRespondTrafficPolicyNotAllowed` 400 from the API
- Updates `create_allow_respond` schema description and docs to document the limitation
- Adds two acceptance tests (`requireHardware`): one verifying the plan-time error with an external zone destination, one verifying success with a non-external destination

## Test plan

- [x] `task test:unit` — all unit tests pass
- [x] `task test:acc -- -run TestAccFirewallPolicy_createAllowRespondExternalZone` on hardware — plan fails with `create_allow_respond is not supported for policies targeting the external zone`
- [x] `task test:acc -- -run TestAccFirewallPolicy_createAllowRespondNonExternal` on hardware — policy created successfully with `create_allow_respond = true`

🤖 Generated with [Claude Code](https://claude.com/claude-code)