### PR TITLE
add vlan only networks

### DIFF
--- a/internal/generate/generate_test.go
+++ b/internal/generate/generate_test.go
@@ -723,6 +723,63 @@ func TestNetworkBlocks_defaults(t *testing.T) {
 	assert.False(t, hasInternet)
 }
 
+func TestNetworkBlocks_vlanOnly(t *testing.T) {
+	iotName := "IoT"
+	iotVLAN := int64(100)
+	iotGroup := "LAN"
+	mgmtName := "Management"
+	mgmtVLAN := int64(10)
+
+	networks := []unifi.Network{
+		{
+			ID:           "net1",
+			Purpose:      "vlan-only",
+			Name:         &iotName,
+			VLAN:         &iotVLAN,
+			NetworkGroup: &iotGroup,
+		},
+		{
+			// Non-LAN group should appear in output.
+			ID:           "net2",
+			Purpose:      "vlan-only",
+			Name:         &mgmtName,
+			VLAN:         &mgmtVLAN,
+			NetworkGroup: func() *string { s := "VLAN"; return &s }(),
+		},
+		{
+			ID:      "net3",
+			Purpose: "wan",
+		},
+	}
+
+	blocks := NetworkBlocks(networks)
+	require.Len(t, blocks, 2) // WAN filtered out
+
+	// IoT: LAN group omitted (it's the default), no DHCP/subnet/internet_access_enabled
+	b := blocks[0]
+	assert.Equal(t, "terrifi_network", b.ResourceType)
+	assert.Equal(t, "iot", b.ResourceName)
+	attrs := attrMapFromBlock(b)
+	assert.Equal(t, `"IoT"`, attrs["name"])
+	assert.Equal(t, `"vlan-only"`, attrs["purpose"])
+	assert.Equal(t, "100", attrs["vlan_id"])
+	_, hasGroup := attrs["network_group"]
+	assert.False(t, hasGroup, "network_group LAN should be omitted")
+	_, hasSubnet := attrs["subnet"]
+	assert.False(t, hasSubnet)
+	_, hasDHCP := attrs["dhcp_enabled"]
+	assert.False(t, hasDHCP)
+	_, hasInternet := attrs["internet_access_enabled"]
+	assert.False(t, hasInternet)
+
+	// Management: non-LAN group is included
+	b2 := blocks[1]
+	attrs2 := attrMapFromBlock(b2)
+	assert.Equal(t, `"vlan-only"`, attrs2["purpose"])
+	assert.Equal(t, "10", attrs2["vlan_id"])
+	assert.Equal(t, `"VLAN"`, attrs2["network_group"])
+}
+
 // ---------------------------------------------------------------------------
 // WLANBlocks
 // ---------------------------------------------------------------------------

--- a/internal/generate/network.go
+++ b/internal/generate/network.go
@@ -5,11 +5,14 @@ import (
 )
 
 // NetworkBlocks generates import + resource blocks for networks.
-// Only corporate networks are included (the provider only supports corporate).
+// Both corporate and vlan-only networks are included.
 func NetworkBlocks(networks []unifi.Network) []ResourceBlock {
 	blocks := make([]ResourceBlock, 0, len(networks))
 	for _, n := range networks {
-		if n.Purpose != "corporate" {
+		switch n.Purpose {
+		case "corporate", "vlan-only":
+			// supported
+		default:
 			continue
 		}
 
@@ -25,48 +28,51 @@ func NetworkBlocks(networks []unifi.Network) []ResourceBlock {
 		}
 
 		block.Attributes = append(block.Attributes, Attr{Key: "name", Value: HCLString(name)})
-		block.Attributes = append(block.Attributes, Attr{Key: "purpose", Value: HCLString("corporate")})
+		block.Attributes = append(block.Attributes, Attr{Key: "purpose", Value: HCLString(n.Purpose)})
 
 		if n.VLAN != nil && *n.VLAN != 0 {
 			block.Attributes = append(block.Attributes, Attr{Key: "vlan_id", Value: HCLInt64(*n.VLAN)})
 		}
-		if n.IPSubnet != nil && *n.IPSubnet != "" {
-			block.Attributes = append(block.Attributes, Attr{Key: "subnet", Value: HCLString(*n.IPSubnet)})
-		}
 		if n.NetworkGroup != nil && *n.NetworkGroup != "" && *n.NetworkGroup != "LAN" {
 			block.Attributes = append(block.Attributes, Attr{Key: "network_group", Value: HCLString(*n.NetworkGroup)})
 		}
-		if n.DHCPDEnabled {
-			block.Attributes = append(block.Attributes, Attr{Key: "dhcp_enabled", Value: HCLBool(true)})
-			if n.DHCPDStart != nil && *n.DHCPDStart != "" {
-				block.Attributes = append(block.Attributes, Attr{Key: "dhcp_start", Value: HCLString(*n.DHCPDStart)})
-			}
-			if n.DHCPDStop != nil && *n.DHCPDStop != "" {
-				block.Attributes = append(block.Attributes, Attr{Key: "dhcp_stop", Value: HCLString(*n.DHCPDStop)})
-			}
-			if n.DHCPDLeaseTime != nil && *n.DHCPDLeaseTime != 86400 {
-				block.Attributes = append(block.Attributes, Attr{Key: "dhcp_lease", Value: HCLInt64(*n.DHCPDLeaseTime)})
-			}
 
-			var dnsServers []string
-			if n.DHCPDDNS1 != "" {
-				dnsServers = append(dnsServers, n.DHCPDDNS1)
+		if n.Purpose == "corporate" {
+			if n.IPSubnet != nil && *n.IPSubnet != "" {
+				block.Attributes = append(block.Attributes, Attr{Key: "subnet", Value: HCLString(*n.IPSubnet)})
 			}
-			if n.DHCPDDNS2 != "" {
-				dnsServers = append(dnsServers, n.DHCPDDNS2)
+			if n.DHCPDEnabled {
+				block.Attributes = append(block.Attributes, Attr{Key: "dhcp_enabled", Value: HCLBool(true)})
+				if n.DHCPDStart != nil && *n.DHCPDStart != "" {
+					block.Attributes = append(block.Attributes, Attr{Key: "dhcp_start", Value: HCLString(*n.DHCPDStart)})
+				}
+				if n.DHCPDStop != nil && *n.DHCPDStop != "" {
+					block.Attributes = append(block.Attributes, Attr{Key: "dhcp_stop", Value: HCLString(*n.DHCPDStop)})
+				}
+				if n.DHCPDLeaseTime != nil && *n.DHCPDLeaseTime != 86400 {
+					block.Attributes = append(block.Attributes, Attr{Key: "dhcp_lease", Value: HCLInt64(*n.DHCPDLeaseTime)})
+				}
+
+				var dnsServers []string
+				if n.DHCPDDNS1 != "" {
+					dnsServers = append(dnsServers, n.DHCPDDNS1)
+				}
+				if n.DHCPDDNS2 != "" {
+					dnsServers = append(dnsServers, n.DHCPDDNS2)
+				}
+				if n.DHCPDDNS3 != "" {
+					dnsServers = append(dnsServers, n.DHCPDDNS3)
+				}
+				if n.DHCPDDNS4 != "" {
+					dnsServers = append(dnsServers, n.DHCPDDNS4)
+				}
+				if len(dnsServers) > 0 {
+					block.Attributes = append(block.Attributes, Attr{Key: "dhcp_dns", Value: HCLStringList(dnsServers)})
+				}
 			}
-			if n.DHCPDDNS3 != "" {
-				dnsServers = append(dnsServers, n.DHCPDDNS3)
+			if !n.InternetAccessEnabled {
+				block.Attributes = append(block.Attributes, Attr{Key: "internet_access_enabled", Value: HCLBool(false)})
 			}
-			if n.DHCPDDNS4 != "" {
-				dnsServers = append(dnsServers, n.DHCPDDNS4)
-			}
-			if len(dnsServers) > 0 {
-				block.Attributes = append(block.Attributes, Attr{Key: "dhcp_dns", Value: HCLStringList(dnsServers)})
-			}
-		}
-		if !n.InternetAccessEnabled {
-			block.Attributes = append(block.Attributes, Attr{Key: "internet_access_enabled", Value: HCLBool(false)})
 		}
 
 		blocks = append(blocks, block)

--- a/internal/provider/network_resource.go
+++ b/internal/provider/network_resource.go
@@ -25,6 +25,7 @@ import (
 var (
 	_ resource.Resource                = &networkResource{}
 	_ resource.ResourceWithImportState = &networkResource{}
+	_ resource.ResourceWithModifyPlan  = &networkResource{}
 )
 
 func NewNetworkResource() resource.Resource {
@@ -92,13 +93,13 @@ func (r *networkResource) Schema(
 			},
 
 			"purpose": schema.StringAttribute{
-				MarkdownDescription: "The purpose of the network. Must be `corporate`.",
+				MarkdownDescription: "The purpose of the network. One of: `corporate`, `vlan-only`.",
 				Required:            true,
 				PlanModifiers: []planmodifier.String{
 					stringplanmodifier.RequiresReplace(),
 				},
 				Validators: []validator.String{
-					stringvalidator.OneOf("corporate"),
+					stringvalidator.OneOf("corporate", "vlan-only"),
 				},
 			},
 
@@ -306,6 +307,53 @@ func (r *networkResource) ImportState(
 	resource.ImportStatePassthroughID(ctx, path.Root("id"), req, resp)
 }
 
+func (r *networkResource) ModifyPlan(
+	ctx context.Context,
+	req resource.ModifyPlanRequest,
+	resp *resource.ModifyPlanResponse,
+) {
+	// During destroy the plan is null — nothing to modify.
+	if req.Plan.Raw.IsNull() {
+		return
+	}
+
+	var plan networkResourceModel
+	resp.Diagnostics.Append(req.Plan.Get(ctx, &plan)...)
+	if resp.Diagnostics.HasError() {
+		return
+	}
+
+	if plan.Purpose.ValueString() != "vlan-only" {
+		return
+	}
+
+	// vlan-only networks carry no IP configuration or DHCP. Null out those
+	// fields so schema defaults (e.g. dhcp_lease=86400) don't produce a
+	// perpetual plan diff against the API response, which omits them entirely.
+	plan.Subnet = types.StringNull()
+	plan.DHCPEnabled = types.BoolValue(false)
+	plan.DHCPStart = types.StringNull()
+	plan.DHCPStop = types.StringNull()
+	plan.DHCPLease = types.Int64Null()
+	plan.DHCPDns = types.ListNull(types.StringType)
+
+	// internet_access_enabled is not meaningful for vlan-only networks. Override
+	// the schema default (true) to false — but only when the user did not
+	// explicitly set the field in their config. If the user set it explicitly we
+	// must leave the plan value alone or Terraform will reject the plan with
+	// "planned value does not match config value".
+	var config networkResourceModel
+	resp.Diagnostics.Append(req.Config.Get(ctx, &config)...)
+	if resp.Diagnostics.HasError() {
+		return
+	}
+	if config.InternetAccessEnabled.IsNull() {
+		plan.InternetAccessEnabled = types.BoolValue(false)
+	}
+
+	resp.Diagnostics.Append(resp.Plan.Set(ctx, &plan)...)
+}
+
 // ---------------------------------------------------------------------------
 // Helper methods
 // ---------------------------------------------------------------------------
@@ -348,7 +396,6 @@ func (r *networkResource) modelToAPI(ctx context.Context, m *networkResourceMode
 		Purpose: m.Purpose.ValueString(),
 		Enabled: true,
 	}
-	applySDKSettingPreferenceWorkaround(net)
 
 	if !m.Name.IsNull() {
 		name := m.Name.ValueString()
@@ -363,69 +410,75 @@ func (r *networkResource) modelToAPI(ctx context.Context, m *networkResourceMode
 		}
 	}
 
-	if !m.Subnet.IsNull() {
-		subnet := m.Subnet.ValueString()
-		net.IPSubnet = &subnet
-	}
-
 	if !m.NetworkGroup.IsNull() {
 		group := m.NetworkGroup.ValueString()
 		net.NetworkGroup = &group
 	}
 
-	if !m.DHCPEnabled.IsNull() {
-		net.DHCPDEnabled = m.DHCPEnabled.ValueBool()
-	}
+	// Subnet, DHCP, and the setting_preference workaround only apply to
+	// corporate networks. vlan-only networks carry no IP configuration.
+	if m.Purpose.ValueString() == "corporate" {
+		applySDKSettingPreferenceWorkaround(net)
 
-	// TODO(go-unifi): The IsUnknown() guards on DHCP fields below work around a
-	// bug in the SDK's marshalCorporate() (network_encode.go). That function uses
-	// valueOrDefault(n.DHCPDStart, defaultStart) which unconditionally sends DHCP
-	// range values even when the caller leaves them nil. During a Terraform create,
-	// computed+optional fields like dhcp_start/dhcp_stop are "unknown" (not null),
-	// so ValueString() returns "". Passing &"" to the SDK causes marshalCorporate()
-	// to serialize empty strings, which crashes the controller with:
-	//   java.lang.IllegalArgumentException: Could not parse []
-	// When the SDK is fixed (e.g., by not defaulting nil pointer fields), the
-	// IsUnknown() checks here can be collapsed back to just IsNull().
-	if !m.DHCPStart.IsNull() && !m.DHCPStart.IsUnknown() {
-		start := m.DHCPStart.ValueString()
-		net.DHCPDStart = &start
-	}
+		if !m.Subnet.IsNull() {
+			subnet := m.Subnet.ValueString()
+			net.IPSubnet = &subnet
+		}
 
-	if !m.DHCPStop.IsNull() && !m.DHCPStop.IsUnknown() {
-		stop := m.DHCPStop.ValueString()
-		net.DHCPDStop = &stop
-	}
+		if !m.DHCPEnabled.IsNull() {
+			net.DHCPDEnabled = m.DHCPEnabled.ValueBool()
+		}
 
-	if !m.DHCPLease.IsNull() && !m.DHCPLease.IsUnknown() {
-		lease := m.DHCPLease.ValueInt64()
-		net.DHCPDLeaseTime = &lease
-	}
+		// TODO(go-unifi): The IsUnknown() guards on DHCP fields below work around a
+		// bug in the SDK's marshalCorporate() (network_encode.go). That function uses
+		// valueOrDefault(n.DHCPDStart, defaultStart) which unconditionally sends DHCP
+		// range values even when the caller leaves them nil. During a Terraform create,
+		// computed+optional fields like dhcp_start/dhcp_stop are "unknown" (not null),
+		// so ValueString() returns "". Passing &"" to the SDK causes marshalCorporate()
+		// to serialize empty strings, which crashes the controller with:
+		//   java.lang.IllegalArgumentException: Could not parse []
+		// When the SDK is fixed (e.g., by not defaulting nil pointer fields), the
+		// IsUnknown() checks here can be collapsed back to just IsNull().
+		if !m.DHCPStart.IsNull() && !m.DHCPStart.IsUnknown() {
+			start := m.DHCPStart.ValueString()
+			net.DHCPDStart = &start
+		}
 
-	if !m.DHCPDns.IsNull() && !m.DHCPDns.IsUnknown() {
-		var dnsServers []types.String
-		m.DHCPDns.ElementsAs(ctx, &dnsServers, false)
+		if !m.DHCPStop.IsNull() && !m.DHCPStop.IsUnknown() {
+			stop := m.DHCPStop.ValueString()
+			net.DHCPDStop = &stop
+		}
 
-		for i, dns := range dnsServers {
-			if i >= 4 {
-				break
-			}
-			dnsVal := dns.ValueString()
-			switch i {
-			case 0:
-				net.DHCPDDNS1 = dnsVal
-			case 1:
-				net.DHCPDDNS2 = dnsVal
-			case 2:
-				net.DHCPDDNS3 = dnsVal
-			case 3:
-				net.DHCPDDNS4 = dnsVal
+		if !m.DHCPLease.IsNull() && !m.DHCPLease.IsUnknown() {
+			lease := m.DHCPLease.ValueInt64()
+			net.DHCPDLeaseTime = &lease
+		}
+
+		if !m.DHCPDns.IsNull() && !m.DHCPDns.IsUnknown() {
+			var dnsServers []types.String
+			m.DHCPDns.ElementsAs(ctx, &dnsServers, false)
+
+			for i, dns := range dnsServers {
+				if i >= 4 {
+					break
+				}
+				dnsVal := dns.ValueString()
+				switch i {
+				case 0:
+					net.DHCPDDNS1 = dnsVal
+				case 1:
+					net.DHCPDDNS2 = dnsVal
+				case 2:
+					net.DHCPDDNS3 = dnsVal
+				case 3:
+					net.DHCPDDNS4 = dnsVal
+				}
 			}
 		}
-	}
 
-	if !m.InternetAccessEnabled.IsNull() {
-		net.InternetAccessEnabled = m.InternetAccessEnabled.ValueBool()
+		if !m.InternetAccessEnabled.IsNull() {
+			net.InternetAccessEnabled = m.InternetAccessEnabled.ValueBool()
+		}
 	}
 
 	return net
@@ -448,64 +501,83 @@ func (r *networkResource) apiToModel(ctx context.Context, net *unifi.Network, m 
 		m.VLANId = types.Int64Null()
 	}
 
-	if net.IPSubnet != nil && *net.IPSubnet != "" {
-		m.Subnet = types.StringPointerValue(net.IPSubnet)
-	} else {
-		m.Subnet = types.StringNull()
-	}
-
 	if net.NetworkGroup != nil && *net.NetworkGroup != "" {
 		m.NetworkGroup = types.StringPointerValue(net.NetworkGroup)
 	} else {
-		m.NetworkGroup = types.StringNull()
+		// Fall back to the schema default so state is never null, which would
+		// cause a perpetual diff against the default "LAN" value at plan time.
+		m.NetworkGroup = types.StringValue("LAN")
 	}
 
-	m.DHCPEnabled = types.BoolValue(net.DHCPDEnabled)
-
-	if net.DHCPDStart != nil && *net.DHCPDStart != "" {
-		m.DHCPStart = types.StringPointerValue(net.DHCPDStart)
-	} else {
-		m.DHCPStart = types.StringNull()
-	}
-
-	if net.DHCPDStop != nil && *net.DHCPDStop != "" {
-		m.DHCPStop = types.StringPointerValue(net.DHCPDStop)
-	} else {
-		m.DHCPStop = types.StringNull()
-	}
-
-	if net.DHCPDLeaseTime != nil && *net.DHCPDLeaseTime != 0 {
-		m.DHCPLease = types.Int64PointerValue(net.DHCPDLeaseTime)
-	} else {
-		m.DHCPLease = types.Int64Null()
-	}
-
-	// Collect non-empty DNS servers into a list
-	var dnsServers []string
-	if net.DHCPDDNS1 != "" {
-		dnsServers = append(dnsServers, net.DHCPDDNS1)
-	}
-	if net.DHCPDDNS2 != "" {
-		dnsServers = append(dnsServers, net.DHCPDDNS2)
-	}
-	if net.DHCPDDNS3 != "" {
-		dnsServers = append(dnsServers, net.DHCPDDNS3)
-	}
-	if net.DHCPDDNS4 != "" {
-		dnsServers = append(dnsServers, net.DHCPDDNS4)
-	}
-
-	if len(dnsServers) > 0 {
-		var dnsValues []types.String
-		for _, dns := range dnsServers {
-			dnsValues = append(dnsValues, types.StringValue(dns))
+	// Subnet, DHCP, and internet_access_enabled are only meaningful for
+	// corporate networks. Null them out for vlan-only so the state matches
+	// what ModifyPlan produces and there is no perpetual diff.
+	if net.Purpose == "corporate" {
+		if net.IPSubnet != nil && *net.IPSubnet != "" {
+			m.Subnet = types.StringPointerValue(net.IPSubnet)
+		} else {
+			m.Subnet = types.StringNull()
 		}
-		m.DHCPDns = types.ListValueMust(types.StringType, toAttrValues(dnsValues))
-	} else {
-		m.DHCPDns = types.ListNull(types.StringType)
-	}
 
-	m.InternetAccessEnabled = types.BoolValue(net.InternetAccessEnabled)
+		m.DHCPEnabled = types.BoolValue(net.DHCPDEnabled)
+
+		if net.DHCPDStart != nil && *net.DHCPDStart != "" {
+			m.DHCPStart = types.StringPointerValue(net.DHCPDStart)
+		} else {
+			m.DHCPStart = types.StringNull()
+		}
+
+		if net.DHCPDStop != nil && *net.DHCPDStop != "" {
+			m.DHCPStop = types.StringPointerValue(net.DHCPDStop)
+		} else {
+			m.DHCPStop = types.StringNull()
+		}
+
+		if net.DHCPDLeaseTime != nil && *net.DHCPDLeaseTime != 0 {
+			m.DHCPLease = types.Int64PointerValue(net.DHCPDLeaseTime)
+		} else {
+			m.DHCPLease = types.Int64Null()
+		}
+
+		// Collect non-empty DNS servers into a list.
+		var dnsServers []string
+		if net.DHCPDDNS1 != "" {
+			dnsServers = append(dnsServers, net.DHCPDDNS1)
+		}
+		if net.DHCPDDNS2 != "" {
+			dnsServers = append(dnsServers, net.DHCPDDNS2)
+		}
+		if net.DHCPDDNS3 != "" {
+			dnsServers = append(dnsServers, net.DHCPDDNS3)
+		}
+		if net.DHCPDDNS4 != "" {
+			dnsServers = append(dnsServers, net.DHCPDDNS4)
+		}
+
+		if len(dnsServers) > 0 {
+			var dnsValues []types.String
+			for _, dns := range dnsServers {
+				dnsValues = append(dnsValues, types.StringValue(dns))
+			}
+			m.DHCPDns = types.ListValueMust(types.StringType, toAttrValues(dnsValues))
+		} else {
+			m.DHCPDns = types.ListNull(types.StringType)
+		}
+
+		m.InternetAccessEnabled = types.BoolValue(net.InternetAccessEnabled)
+	} else {
+		// vlan-only: null out all IP/DHCP fields.
+		m.Subnet = types.StringNull()
+		m.DHCPEnabled = types.BoolValue(false)
+		m.DHCPStart = types.StringNull()
+		m.DHCPStop = types.StringNull()
+		m.DHCPLease = types.Int64Null()
+		m.DHCPDns = types.ListNull(types.StringType)
+		// internet_access_enabled is not sent to the API for vlan-only networks.
+		// Store false so it matches what ModifyPlan produces, avoiding a
+		// perpetual diff after import or refresh.
+		m.InternetAccessEnabled = types.BoolValue(false)
+	}
 }
 
 func toAttrValues(vals []types.String) []attr.Value {

--- a/internal/provider/network_resource_test.go
+++ b/internal/provider/network_resource_test.go
@@ -77,6 +77,38 @@ func TestNetworkModelToAPI(t *testing.T) {
 		assert.Equal(t, int64(86400), *net.DHCPDLeaseTime)
 	})
 
+	t.Run("vlan-only network skips DHCP and subnet", func(t *testing.T) {
+		model := &networkResourceModel{
+			Name:         types.StringValue("IoT VLAN"),
+			Purpose:      types.StringValue("vlan-only"),
+			VLANId:       types.Int64Value(100),
+			NetworkGroup: types.StringValue("LAN"),
+			// These fields would be nulled by ModifyPlan at plan time, but we
+			// test modelToAPI in isolation so pass null explicitly.
+			Subnet:      types.StringNull(),
+			DHCPEnabled: types.BoolValue(false),
+			DHCPStart:   types.StringNull(),
+			DHCPStop:    types.StringNull(),
+			DHCPLease:   types.Int64Null(),
+			DHCPDns:     types.ListNull(types.StringType),
+		}
+
+		net := r.modelToAPI(ctx, model)
+
+		assert.Equal(t, "vlan-only", net.Purpose)
+		require.NotNil(t, net.VLAN)
+		assert.Equal(t, int64(100), *net.VLAN)
+		assert.True(t, net.VLANEnabled)
+		// Subnet and DHCP must NOT be set for vlan-only.
+		assert.Nil(t, net.IPSubnet)
+		assert.False(t, net.DHCPDEnabled)
+		assert.Nil(t, net.DHCPDStart)
+		assert.Nil(t, net.DHCPDStop)
+		assert.Nil(t, net.DHCPDLeaseTime)
+		// Setting-preference workaround must NOT be applied for vlan-only.
+		assert.Nil(t, net.SettingPreference)
+	})
+
 	t.Run("dhcp dns list fans out to API fields", func(t *testing.T) {
 		model := &networkResourceModel{
 			Name:    types.StringValue("DNS Test"),
@@ -159,6 +191,35 @@ func TestNetworkAPIToModel(t *testing.T) {
 		assert.Equal(t, "192.168.33.10", model.DHCPStart.ValueString())
 		assert.Equal(t, "192.168.33.250", model.DHCPStop.ValueString())
 		assert.Equal(t, int64(86400), model.DHCPLease.ValueInt64())
+	})
+
+	t.Run("vlan-only network nulls out DHCP and subnet", func(t *testing.T) {
+		name := "IoT VLAN"
+		vlan := int64(100)
+		group := "LAN"
+
+		net := &unifi.Network{
+			ID:          "vlan123",
+			Purpose:     "vlan-only",
+			Name:        &name,
+			VLAN:        &vlan,
+			VLANEnabled: true,
+			NetworkGroup: &group,
+		}
+
+		var model networkResourceModel
+		r.apiToModel(ctx, net, &model, "default")
+
+		assert.Equal(t, "vlan-only", model.Purpose.ValueString())
+		assert.Equal(t, int64(100), model.VLANId.ValueInt64())
+		assert.Equal(t, "LAN", model.NetworkGroup.ValueString())
+		// All IP/DHCP fields must be null for vlan-only.
+		assert.True(t, model.Subnet.IsNull())
+		assert.False(t, model.DHCPEnabled.ValueBool())
+		assert.True(t, model.DHCPStart.IsNull())
+		assert.True(t, model.DHCPStop.IsNull())
+		assert.True(t, model.DHCPLease.IsNull())
+		assert.True(t, model.DHCPDns.IsNull())
 	})
 
 	t.Run("network with DNS servers", func(t *testing.T) {


### PR DESCRIPTION
I am using OPNsense as router and only have some VLAN networks that are exposed via WiFi. 
This PR enables support for theses kinds of networks. 

Coded with Claude and tested in my local tofu repo.