### PR TITLE
Add HIL test for vlan-only networks; fix network_group in generate

### DIFF
--- a/cmd/terrifi/generate_imports_test.go
+++ b/cmd/terrifi/generate_imports_test.go
@@ -331,6 +331,59 @@ resource "terrifi_network" "test" {
 	})
 }
 
+func TestAccGenerateImports_Network_VlanOnly(t *testing.T) {
+	requireHardware(t)
+	name := fmt.Sprintf("terrifi-test-vlan-%s", randomSuffix())
+	vlan := randomVLAN()
+
+	resource.Test(t, resource.TestCase{
+		ProtoV6ProviderFactories: testAccProtoV6ProviderFactories,
+		Steps: []resource.TestStep{
+			{
+				Config: fmt.Sprintf(`
+resource "terrifi_network" "test" {
+  name    = %q
+  purpose = "vlan-only"
+  vlan_id = %d
+}
+`, name, vlan),
+				Check: func(s *terraform.State) error {
+					id, err := resourceID(s, "terrifi_network.test")
+					if err != nil {
+						return err
+					}
+					tfName := strings.ReplaceAll(name, "-", "_")
+					output := runCLI(t, "generate-imports", "terrifi_network")
+					checks := []struct {
+						want   string
+						absent bool
+					}{
+						{want: fmt.Sprintf(`id = "%s"`, id)},
+						{want: fmt.Sprintf(`terrifi_network.%s`, tfName)},
+						{want: fmt.Sprintf(`name = "%s"`, name)},
+						{want: `purpose = "vlan-only"`},
+						{want: fmt.Sprintf(`vlan_id = %d`, vlan)},
+						{want: `subnet`, absent: true},
+						{want: `dhcp_enabled`, absent: true},
+						{want: `internet_access_enabled`, absent: true},
+						{want: `network_group`, absent: true},
+					}
+					for _, c := range checks {
+						contains := strings.Contains(output, c.want)
+						if c.absent && contains {
+							return fmt.Errorf("CLI output should not contain %q\n\nFull output:\n%s", c.want, output)
+						}
+						if !c.absent && !contains {
+							return fmt.Errorf("CLI output missing expected string %q\n\nFull output:\n%s", c.want, output)
+						}
+					}
+					return nil
+				},
+			},
+		},
+	})
+}
+
 func TestAccGenerateImports_WLAN(t *testing.T) {
 	requireHardware(t)
 	suffix := randomSuffix()

--- a/docs/resources/network.md
+++ b/docs/resources/network.md
@@ -7,7 +7,7 @@ description: |-
 
 # terrifi_network (Resource)
 
-Manages a network on the UniFi controller. Supports corporate network types with VLAN configuration and DHCP settings.
+Manages a network on the UniFi controller. Supports `corporate` networks with VLAN configuration and DHCP settings, and `vlan-only` networks that carry no IP configuration.
 
 ## Example Usage
 
@@ -29,12 +29,22 @@ resource "terrifi_network" "iot" {
 }
 ```
 
+### VLAN-only network
+
+```terraform
+resource "terrifi_network" "cameras" {
+  name    = "Cameras"
+  purpose = "vlan-only"
+  vlan_id = 20
+}
+```
+
 ## Schema
 
 ### Required
 
 - `name` (String) — The name of the network.
-- `purpose` (String) — The purpose of the network. For now this must be `corporate`. We might support others in the future but it's more complicated to implement and test.
+- `purpose` (String) — The purpose of the network. One of: `corporate`, `vlan-only`.
 
 ### Optional
 

--- a/internal/generate/generate_test.go
+++ b/internal/generate/generate_test.go
@@ -739,7 +739,7 @@ func TestNetworkBlocks_vlanOnly(t *testing.T) {
 			NetworkGroup: &iotGroup,
 		},
 		{
-			// Non-LAN group should appear in output.
+			// Non-LAN group is ignored for vlan-only — the API rejects it.
 			ID:           "net2",
 			Purpose:      "vlan-only",
 			Name:         &mgmtName,
@@ -772,12 +772,13 @@ func TestNetworkBlocks_vlanOnly(t *testing.T) {
 	_, hasInternet := attrs["internet_access_enabled"]
 	assert.False(t, hasInternet)
 
-	// Management: non-LAN group is included
+	// Management: network_group is omitted even when non-LAN — not valid for vlan-only.
 	b2 := blocks[1]
 	attrs2 := attrMapFromBlock(b2)
 	assert.Equal(t, `"vlan-only"`, attrs2["purpose"])
 	assert.Equal(t, "10", attrs2["vlan_id"])
-	assert.Equal(t, `"VLAN"`, attrs2["network_group"])
+	_, hasMgmtGroup := attrs2["network_group"]
+	assert.False(t, hasMgmtGroup, "network_group should be omitted for vlan-only")
 }
 
 // ---------------------------------------------------------------------------

--- a/internal/generate/network.go
+++ b/internal/generate/network.go
@@ -33,11 +33,11 @@ func NetworkBlocks(networks []unifi.Network) []ResourceBlock {
 		if n.VLAN != nil && *n.VLAN != 0 {
 			block.Attributes = append(block.Attributes, Attr{Key: "vlan_id", Value: HCLInt64(*n.VLAN)})
 		}
-		if n.NetworkGroup != nil && *n.NetworkGroup != "" && *n.NetworkGroup != "LAN" {
-			block.Attributes = append(block.Attributes, Attr{Key: "network_group", Value: HCLString(*n.NetworkGroup)})
-		}
 
 		if n.Purpose == "corporate" {
+			if n.NetworkGroup != nil && *n.NetworkGroup != "" && *n.NetworkGroup != "LAN" {
+				block.Attributes = append(block.Attributes, Attr{Key: "network_group", Value: HCLString(*n.NetworkGroup)})
+			}
 			if n.IPSubnet != nil && *n.IPSubnet != "" {
 				block.Attributes = append(block.Attributes, Attr{Key: "subnet", Value: HCLString(*n.IPSubnet)})
 			}

--- a/internal/provider/network_resource_test.go
+++ b/internal/provider/network_resource_test.go
@@ -467,6 +467,64 @@ resource "terrifi_network" "test" {
 	})
 }
 
+func TestAccNetwork_vlanOnly(t *testing.T) {
+	name := fmt.Sprintf("tfacc-vlan-%s", randomSuffix())
+	nameUpdated := fmt.Sprintf("tfacc-vlan-upd-%s", randomSuffix())
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:                 func() { preCheck(t) },
+		ProtoV6ProviderFactories: testAccProtoV6ProviderFactories,
+		Steps: []resource.TestStep{
+			// Step 1: create minimal vlan-only network (no subnet, DHCP, internet fields).
+			{
+				Config: fmt.Sprintf(`
+resource "terrifi_network" "test" {
+  name    = %q
+  purpose = "vlan-only"
+  vlan_id = 200
+}
+`, name),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr("terrifi_network.test", "name", name),
+					resource.TestCheckResourceAttr("terrifi_network.test", "purpose", "vlan-only"),
+					resource.TestCheckResourceAttr("terrifi_network.test", "vlan_id", "200"),
+					resource.TestCheckResourceAttr("terrifi_network.test", "network_group", "LAN"),
+					resource.TestCheckResourceAttr("terrifi_network.test", "dhcp_enabled", "false"),
+					resource.TestCheckNoResourceAttr("terrifi_network.test", "subnet"),
+					resource.TestCheckNoResourceAttr("terrifi_network.test", "dhcp_start"),
+					resource.TestCheckNoResourceAttr("terrifi_network.test", "dhcp_stop"),
+					resource.TestCheckNoResourceAttr("terrifi_network.test", "dhcp_lease"),
+					resource.TestCheckResourceAttrSet("terrifi_network.test", "id"),
+					resource.TestCheckResourceAttr("terrifi_network.test", "site", "default"),
+				),
+			},
+			// Step 2: update name only — no plan diff on DHCP/subnet fields.
+			{
+				Config: fmt.Sprintf(`
+resource "terrifi_network" "test" {
+  name    = %q
+  purpose = "vlan-only"
+  vlan_id = 200
+}
+`, nameUpdated),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr("terrifi_network.test", "name", nameUpdated),
+					resource.TestCheckResourceAttr("terrifi_network.test", "purpose", "vlan-only"),
+					resource.TestCheckResourceAttr("terrifi_network.test", "vlan_id", "200"),
+					resource.TestCheckResourceAttr("terrifi_network.test", "dhcp_enabled", "false"),
+					resource.TestCheckNoResourceAttr("terrifi_network.test", "subnet"),
+				),
+			},
+			// Step 3: import round-trip — state must round-trip cleanly with no diff.
+			{
+				ResourceName:      "terrifi_network.test",
+				ImportState:       true,
+				ImportStateVerify: true,
+			},
+		},
+	})
+}
+
 func TestAccNetwork_importSiteID(t *testing.T) {
 	name := fmt.Sprintf("tfacc-impsid-%s", randomSuffix())
 	resource.Test(t, resource.TestCase{


### PR DESCRIPTION
## Summary

Follow-up polish on top of #126 (vlan-only network support).

- **`internal/generate/network.go`**: `network_group` was outside the `corporate`-only block, so `generate-imports` would emit it for vlan-only networks — but the controller returns 400 when it's set on a vlan-only network. Moved it inside the guard.
- **`internal/generate/generate_test.go`**: Update `TestNetworkBlocks_vlanOnly` to assert `network_group` is absent for vlan-only.
- **`internal/provider/network_resource_test.go`**: Add `TestAccNetwork_vlanOnly` — HIL acceptance test (Docker) covering create, rename, and import round-trip.
- **`cmd/terrifi/generate_imports_test.go`**: Add `TestAccGenerateImports_Network_VlanOnly` — CLI end-to-end test (hardware) asserting correct output and absence of corporate-only fields.
- **`docs/resources/network.md`**: Update description, `purpose` schema entry, and add a vlan-only example.

## Test plan

- [x] `task test:acc -- -run TestAccNetwork_vlanOnly` passes against Docker controller
- [x] `go test ./internal/generate/ -run TestNetworkBlocks_vlanOnly` passes
- [ ] `TestAccGenerateImports_Network_VlanOnly` — requires hardware