### PR TITLE
Upgrade GitHub Actions to Node.js 24 compatible versions

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -16,7 +16,7 @@ jobs:
     runs-on: ubuntu-24.04
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         with:
           fetch-depth: 0
       - name: Create and push tag
@@ -24,17 +24,17 @@ jobs:
           git tag "${{ github.event.inputs.tag }}"
           git push origin "${{ github.event.inputs.tag }}"
       - name: Import GPG key
-        uses: crazy-max/ghaction-import-gpg@v6
+        uses: crazy-max/ghaction-import-gpg@v7
         id: import_gpg
         with:
           gpg_private_key: ${{ secrets.GPG_PRIVATE_KEY }}
           passphrase: ${{ secrets.GPG_PASSPHRASE }}
       - name: Set up Go
-        uses: actions/setup-go@v5
+        uses: actions/setup-go@v6
         with:
           go-version-file: go.mod
       - name: Run GoReleaser
-        uses: goreleaser/goreleaser-action@v6
+        uses: goreleaser/goreleaser-action@v7
         with:
           version: latest
           args: release --clean


### PR DESCRIPTION
## Summary

- `actions/checkout`: v4 → v6
- `actions/setup-go`: v5 → v6
- `crazy-max/ghaction-import-gpg`: v6 → v7
- `goreleaser/goreleaser-action`: v6 → v7

Node.js 20 actions are deprecated; GitHub will force Node.js 24 starting June 2, 2026.

## Test plan

- [ ] Trigger a release workflow run to verify all steps succeed with upgraded actions

🤖 Generated with [Claude Code](https://claude.com/claude-code)