### PR TITLE
Add terrifi_port_group resource and data source

### DIFF
--- a/cmd/terrifi/generate_imports.go
+++ b/cmd/terrifi/generate_imports.go
@@ -20,6 +20,7 @@ var validResourceTypes = []string{
 	"terrifi_firewall_policy",
 	"terrifi_firewall_policy_order",
 	"terrifi_network",
+	"terrifi_port_group",
 	"terrifi_wlan",
 }
 
@@ -123,6 +124,13 @@ func runGenerateImports(cmd *cobra.Command, args []string) error {
 			return fmt.Errorf("listing networks: %w", err)
 		}
 		blocks = generate.NetworkBlocks(networks)
+
+	case "terrifi_port_group":
+		groups, err := client.ListFirewallGroup(ctx, site)
+		if err != nil {
+			return fmt.Errorf("listing firewall groups: %w", err)
+		}
+		blocks = generate.PortGroupBlocks(groups)
 
 	case "terrifi_wlan":
 		wlans, err := client.ListWLAN(ctx, site)

--- a/docs/data-sources/port_group.md
+++ b/docs/data-sources/port_group.md
@@ -1,0 +1,58 @@
+---
+page_title: "terrifi_port_group Data Source - Terrifi"
+subcategory: ""
+description: |-
+  Looks up a UniFi port group by name.
+---
+
+# terrifi_port_group (Data Source)
+
+Looks up a UniFi port group by name. Use this data source to reference an existing port group in firewall policies without managing it directly.
+
+## Example Usage
+
+### Look up a port group
+
+```terraform
+data "terrifi_port_group" "web" {
+  name = "Web Ports"
+}
+```
+
+### Reference in a firewall policy
+
+```terraform
+data "terrifi_port_group" "web" {
+  name = "Web Ports"
+}
+
+resource "terrifi_firewall_policy" "allow_web" {
+  name   = "Allow Web"
+  action = "ALLOW"
+
+  source {
+    zone_id = terrifi_firewall_zone.lan.id
+  }
+
+  destination {
+    zone_id            = terrifi_firewall_zone.wan.id
+    port_matching_type = "OBJECT"
+    port_group_id      = data.terrifi_port_group.web.id
+  }
+}
+```
+
+## Schema
+
+### Required
+
+- `name` (String) — The name of the port group to look up.
+
+### Optional
+
+- `site` (String) — The site to look up the port group in. Defaults to the provider site.
+
+### Read-Only
+
+- `id` (String) — The ID of the port group.
+- `ports` (Set of String) — The ports in this group. Each entry is a port number (e.g. `"80"`) or a port range (e.g. `"8080-8090"`).

--- a/docs/resources/port_group.md
+++ b/docs/resources/port_group.md
@@ -1,0 +1,89 @@
+---
+page_title: "terrifi_port_group Resource - Terrifi"
+subcategory: ""
+description: |-
+  Manages a port group on the UniFi controller.
+---
+
+# terrifi_port_group (Resource)
+
+Manages a port group on the UniFi controller. Port groups are named collections of port numbers or port ranges that can be referenced by firewall policies and rules.
+
+## Example Usage
+
+### Basic port group
+
+```terraform
+resource "terrifi_port_group" "web" {
+  name  = "Web Ports"
+  ports = ["80", "443"]
+}
+```
+
+### Port range
+
+```terraform
+resource "terrifi_port_group" "ephemeral" {
+  name  = "Ephemeral Ports"
+  ports = ["1024-65535"]
+}
+```
+
+### Usage in a firewall policy
+
+```terraform
+resource "terrifi_port_group" "web" {
+  name  = "Web Ports"
+  ports = ["80", "443"]
+}
+
+resource "terrifi_firewall_policy" "allow_web" {
+  name   = "Allow Web"
+  action = "ALLOW"
+
+  source {
+    zone_id = terrifi_firewall_zone.lan.id
+  }
+
+  destination {
+    zone_id            = terrifi_firewall_zone.wan.id
+    port_matching_type = "OBJECT"
+    port_group_id      = terrifi_port_group.web.id
+  }
+}
+```
+
+## Schema
+
+### Required
+
+- `name` (String) — The name of the port group.
+- `ports` (Set of String) — The ports in this group. Each entry is a port number (e.g. `"80"`) or a port range (e.g. `"8080-8090"`).
+
+### Optional
+
+- `site` (String) — The site to associate the port group with. Defaults to the provider site. Changing this forces a new resource.
+
+### Read-Only
+
+- `id` (String) — The ID of the port group.
+
+## Import
+
+Port groups can be imported using the group ID:
+
+```shell
+terraform import terrifi_port_group.web <id>
+```
+
+To import a port group from a non-default site, use the `site:id` format:
+
+```shell
+terraform import terrifi_port_group.web <site>:<id>
+```
+
+You can also use the [Terrifi CLI](../index.md#cli) to generate import blocks for all port groups automatically:
+
+```shell
+terrifi generate-imports terrifi_port_group
+```

--- a/internal/generate/port_group.go
+++ b/internal/generate/port_group.go
@@ -1,0 +1,27 @@
+package generate
+
+import (
+	"github.com/ubiquiti-community/go-unifi/unifi"
+)
+
+// PortGroupBlocks generates import + resource blocks for port groups.
+func PortGroupBlocks(groups []unifi.FirewallGroup) []ResourceBlock {
+	blocks := make([]ResourceBlock, 0, len(groups))
+	for _, g := range groups {
+		if g.GroupType != "port-group" {
+			continue
+		}
+		block := ResourceBlock{
+			ResourceType: "terrifi_port_group",
+			ResourceName: ToTerraformName(g.Name),
+			ImportID:     g.ID,
+		}
+
+		block.Attributes = append(block.Attributes, Attr{Key: "name", Value: HCLString(g.Name)})
+		block.Attributes = append(block.Attributes, Attr{Key: "ports", Value: HCLStringList(g.GroupMembers)})
+
+		blocks = append(blocks, block)
+	}
+	DeduplicateNames(blocks)
+	return blocks
+}

--- a/internal/provider/port_group_data_source.go
+++ b/internal/provider/port_group_data_source.go
@@ -1,0 +1,147 @@
+package provider
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/hashicorp/terraform-plugin-framework/attr"
+	"github.com/hashicorp/terraform-plugin-framework/datasource"
+	"github.com/hashicorp/terraform-plugin-framework/datasource/schema"
+	"github.com/hashicorp/terraform-plugin-framework/types"
+	"github.com/ubiquiti-community/go-unifi/unifi"
+)
+
+var _ datasource.DataSource = &portGroupDataSource{}
+
+func NewPortGroupDataSource() datasource.DataSource {
+	return &portGroupDataSource{}
+}
+
+type portGroupDataSource struct {
+	client *Client
+}
+
+type portGroupDataSourceModel struct {
+	ID    types.String `tfsdk:"id"`
+	Site  types.String `tfsdk:"site"`
+	Name  types.String `tfsdk:"name"`
+	Ports types.Set    `tfsdk:"ports"`
+}
+
+func (d *portGroupDataSource) Metadata(
+	_ context.Context,
+	req datasource.MetadataRequest,
+	resp *datasource.MetadataResponse,
+) {
+	resp.TypeName = req.ProviderTypeName + "_port_group"
+}
+
+func (d *portGroupDataSource) Schema(
+	_ context.Context,
+	_ datasource.SchemaRequest,
+	resp *datasource.SchemaResponse,
+) {
+	resp.Schema = schema.Schema{
+		MarkdownDescription: "Looks up a UniFi port group by name.",
+
+		Attributes: map[string]schema.Attribute{
+			"name": schema.StringAttribute{
+				MarkdownDescription: "The name of the port group to look up.",
+				Required:            true,
+			},
+
+			"site": schema.StringAttribute{
+				MarkdownDescription: "The site to look up the port group in. Defaults to the provider site.",
+				Optional:            true,
+			},
+
+			"id": schema.StringAttribute{
+				MarkdownDescription: "The ID of the port group.",
+				Computed:            true,
+			},
+
+			"ports": schema.SetAttribute{
+				MarkdownDescription: "The ports in this group. Each entry is a port number (e.g. `\"80\"`) " +
+					"or a port range (e.g. `\"8080-8090\"`).",
+				Computed:    true,
+				ElementType: types.StringType,
+			},
+		},
+	}
+}
+
+func (d *portGroupDataSource) Configure(
+	_ context.Context,
+	req datasource.ConfigureRequest,
+	resp *datasource.ConfigureResponse,
+) {
+	if req.ProviderData == nil {
+		return
+	}
+
+	client, ok := req.ProviderData.(*Client)
+	if !ok {
+		resp.Diagnostics.AddError(
+			"Unexpected Data Source Configure Type",
+			fmt.Sprintf("Expected *Client, got: %T.", req.ProviderData),
+		)
+		return
+	}
+
+	d.client = client
+}
+
+func (d *portGroupDataSource) Read(
+	ctx context.Context,
+	req datasource.ReadRequest,
+	resp *datasource.ReadResponse,
+) {
+	var config portGroupDataSourceModel
+	resp.Diagnostics.Append(req.Config.Get(ctx, &config)...)
+	if resp.Diagnostics.HasError() {
+		return
+	}
+
+	site := d.client.SiteOrDefault(config.Site)
+
+	group, err := d.findPortGroupByName(ctx, site, config.Name.ValueString())
+	if err != nil {
+		resp.Diagnostics.AddError(
+			"Port Group Not Found",
+			fmt.Sprintf("No port group found with name %q in site %q: %s", config.Name.ValueString(), site, err.Error()),
+		)
+		return
+	}
+
+	d.apiToModel(group, &config, site)
+	resp.Diagnostics.Append(resp.State.Set(ctx, &config)...)
+}
+
+func (d *portGroupDataSource) findPortGroupByName(ctx context.Context, site, name string) (*unifi.FirewallGroup, error) {
+	groups, err := d.client.ListFirewallGroup(ctx, site)
+	if err != nil {
+		return nil, err
+	}
+	for i := range groups {
+		if groups[i].GroupType == "port-group" && groups[i].Name == name {
+			return &groups[i], nil
+		}
+	}
+	return nil, fmt.Errorf("not found")
+}
+
+func (d *portGroupDataSource) apiToModel(group *unifi.FirewallGroup, m *portGroupDataSourceModel, site string) {
+	m.ID = types.StringValue(group.ID)
+	m.Site = types.StringValue(site)
+	m.Name = types.StringValue(group.Name)
+
+	if group.GroupMembers != nil {
+		vals := make([]attr.Value, len(group.GroupMembers))
+		for i, port := range group.GroupMembers {
+			vals[i] = types.StringValue(port)
+		}
+		m.Ports = types.SetValueMust(types.StringType, vals)
+	} else {
+		m.Ports = types.SetValueMust(types.StringType, []attr.Value{})
+	}
+}

--- a/internal/provider/port_group_resource.go
+++ b/internal/provider/port_group_resource.go
@@ -1,0 +1,281 @@
+package provider
+
+import (
+	"context"
+	"fmt"
+	"strings"
+
+	"github.com/hashicorp/terraform-plugin-framework/attr"
+	"github.com/hashicorp/terraform-plugin-framework/diag"
+	"github.com/hashicorp/terraform-plugin-framework/path"
+	"github.com/hashicorp/terraform-plugin-framework/resource"
+	"github.com/hashicorp/terraform-plugin-framework/resource/schema"
+	"github.com/hashicorp/terraform-plugin-framework/resource/schema/planmodifier"
+	"github.com/hashicorp/terraform-plugin-framework/resource/schema/stringplanmodifier"
+	"github.com/hashicorp/terraform-plugin-framework/types"
+	"github.com/ubiquiti-community/go-unifi/unifi"
+)
+
+// Compile-time interface checks.
+var (
+	_ resource.Resource                = &portGroupResource{}
+	_ resource.ResourceWithImportState = &portGroupResource{}
+)
+
+func NewPortGroupResource() resource.Resource {
+	return &portGroupResource{}
+}
+
+type portGroupResource struct {
+	client *Client
+}
+
+type portGroupResourceModel struct {
+	ID    types.String `tfsdk:"id"`
+	Site  types.String `tfsdk:"site"`
+	Name  types.String `tfsdk:"name"`
+	Ports types.Set    `tfsdk:"ports"`
+}
+
+func (r *portGroupResource) Metadata(
+	_ context.Context,
+	req resource.MetadataRequest,
+	resp *resource.MetadataResponse,
+) {
+	resp.TypeName = req.ProviderTypeName + "_port_group"
+}
+
+func (r *portGroupResource) Schema(
+	_ context.Context,
+	_ resource.SchemaRequest,
+	resp *resource.SchemaResponse,
+) {
+	resp.Schema = schema.Schema{
+		MarkdownDescription: "Manages a port group on the UniFi controller. Port groups are named collections " +
+			"of port numbers or port ranges that can be referenced by firewall policies and rules.",
+
+		Attributes: map[string]schema.Attribute{
+			"id": schema.StringAttribute{
+				MarkdownDescription: "The ID of the port group.",
+				Computed:            true,
+				PlanModifiers: []planmodifier.String{
+					stringplanmodifier.UseStateForUnknown(),
+				},
+			},
+
+			"site": schema.StringAttribute{
+				MarkdownDescription: "The site to associate the port group with. Defaults to the provider site.",
+				Optional:            true,
+				Computed:            true,
+				PlanModifiers: []planmodifier.String{
+					stringplanmodifier.RequiresReplace(),
+					stringplanmodifier.UseStateForUnknown(),
+				},
+			},
+
+			"name": schema.StringAttribute{
+				MarkdownDescription: "The name of the port group.",
+				Required:            true,
+			},
+
+			"ports": schema.SetAttribute{
+				MarkdownDescription: "The ports in this group. Each entry is a port number (e.g. `\"80\"`) " +
+					"or a port range (e.g. `\"8080-8090\"`).",
+				Required:    true,
+				ElementType: types.StringType,
+			},
+		},
+	}
+}
+
+func (r *portGroupResource) Configure(
+	_ context.Context,
+	req resource.ConfigureRequest,
+	resp *resource.ConfigureResponse,
+) {
+	if req.ProviderData == nil {
+		return
+	}
+
+	client, ok := req.ProviderData.(*Client)
+	if !ok {
+		resp.Diagnostics.AddError(
+			"Unexpected Resource Configure Type",
+			fmt.Sprintf("Expected *Client, got: %T.", req.ProviderData),
+		)
+		return
+	}
+
+	r.client = client
+}
+
+func (r *portGroupResource) Create(
+	ctx context.Context,
+	req resource.CreateRequest,
+	resp *resource.CreateResponse,
+) {
+	var plan portGroupResourceModel
+	resp.Diagnostics.Append(req.Plan.Get(ctx, &plan)...)
+	if resp.Diagnostics.HasError() {
+		return
+	}
+
+	site := r.client.SiteOrDefault(plan.Site)
+	group, diags := r.modelToAPI(ctx, &plan)
+	resp.Diagnostics.Append(diags...)
+	if resp.Diagnostics.HasError() {
+		return
+	}
+
+	created, err := r.client.CreateFirewallGroup(ctx, site, group)
+	if err != nil {
+		resp.Diagnostics.AddError("Error Creating Port Group", err.Error())
+		return
+	}
+
+	r.apiToModel(created, &plan, site)
+	resp.Diagnostics.Append(resp.State.Set(ctx, &plan)...)
+}
+
+func (r *portGroupResource) Read(
+	ctx context.Context,
+	req resource.ReadRequest,
+	resp *resource.ReadResponse,
+) {
+	var state portGroupResourceModel
+	resp.Diagnostics.Append(req.State.Get(ctx, &state)...)
+	if resp.Diagnostics.HasError() {
+		return
+	}
+
+	site := r.client.SiteOrDefault(state.Site)
+
+	group, err := r.client.GetFirewallGroup(ctx, site, state.ID.ValueString())
+	if err != nil {
+		if _, ok := err.(*unifi.NotFoundError); ok {
+			resp.State.RemoveResource(ctx)
+			return
+		}
+		resp.Diagnostics.AddError(
+			"Error Reading Port Group",
+			fmt.Sprintf("Could not read port group %s: %s", state.ID.ValueString(), err.Error()),
+		)
+		return
+	}
+
+	r.apiToModel(group, &state, site)
+	resp.Diagnostics.Append(resp.State.Set(ctx, &state)...)
+}
+
+func (r *portGroupResource) Update(
+	ctx context.Context,
+	req resource.UpdateRequest,
+	resp *resource.UpdateResponse,
+) {
+	var state, plan portGroupResourceModel
+	resp.Diagnostics.Append(req.State.Get(ctx, &state)...)
+	resp.Diagnostics.Append(req.Plan.Get(ctx, &plan)...)
+	if resp.Diagnostics.HasError() {
+		return
+	}
+
+	r.applyPlanToState(&plan, &state)
+
+	site := r.client.SiteOrDefault(state.Site)
+	group, diags := r.modelToAPI(ctx, &state)
+	resp.Diagnostics.Append(diags...)
+	if resp.Diagnostics.HasError() {
+		return
+	}
+	group.ID = state.ID.ValueString()
+
+	updated, err := r.client.UpdateFirewallGroup(ctx, site, group)
+	if err != nil {
+		resp.Diagnostics.AddError("Error Updating Port Group", err.Error())
+		return
+	}
+
+	r.apiToModel(updated, &state, site)
+	resp.Diagnostics.Append(resp.State.Set(ctx, &state)...)
+}
+
+func (r *portGroupResource) Delete(
+	ctx context.Context,
+	req resource.DeleteRequest,
+	resp *resource.DeleteResponse,
+) {
+	var state portGroupResourceModel
+	resp.Diagnostics.Append(req.State.Get(ctx, &state)...)
+	if resp.Diagnostics.HasError() {
+		return
+	}
+
+	site := r.client.SiteOrDefault(state.Site)
+
+	err := r.client.DeleteFirewallGroup(ctx, site, state.ID.ValueString())
+	if err != nil {
+		resp.Diagnostics.AddError("Error Deleting Port Group", err.Error())
+	}
+}
+
+// ImportState supports both "id" and "site:id" import formats.
+func (r *portGroupResource) ImportState(
+	ctx context.Context,
+	req resource.ImportStateRequest,
+	resp *resource.ImportStateResponse,
+) {
+	parts := strings.SplitN(req.ID, ":", 2)
+
+	if len(parts) == 2 {
+		resp.Diagnostics.Append(resp.State.SetAttribute(ctx, path.Root("site"), parts[0])...)
+		resp.Diagnostics.Append(resp.State.SetAttribute(ctx, path.Root("id"), parts[1])...)
+		return
+	}
+
+	resource.ImportStatePassthroughID(ctx, path.Root("id"), req, resp)
+}
+
+// ---------------------------------------------------------------------------
+// Helper methods
+// ---------------------------------------------------------------------------
+
+func (r *portGroupResource) applyPlanToState(plan, state *portGroupResourceModel) {
+	if !plan.Name.IsNull() && !plan.Name.IsUnknown() {
+		state.Name = plan.Name
+	}
+	if !plan.Ports.IsNull() && !plan.Ports.IsUnknown() {
+		state.Ports = plan.Ports
+	}
+}
+
+func (r *portGroupResource) modelToAPI(ctx context.Context, m *portGroupResourceModel) (*unifi.FirewallGroup, diag.Diagnostics) {
+	group := &unifi.FirewallGroup{
+		Name:      m.Name.ValueString(),
+		GroupType: "port-group",
+	}
+
+	var ports []string
+	diags := m.Ports.ElementsAs(ctx, &ports, false)
+	if diags.HasError() {
+		return nil, diags
+	}
+	group.GroupMembers = ports
+
+	return group, diags
+}
+
+func (r *portGroupResource) apiToModel(group *unifi.FirewallGroup, m *portGroupResourceModel, site string) {
+	m.ID = types.StringValue(group.ID)
+	m.Site = types.StringValue(site)
+	m.Name = types.StringValue(group.Name)
+
+	if group.GroupMembers != nil {
+		vals := make([]attr.Value, len(group.GroupMembers))
+		for i, port := range group.GroupMembers {
+			vals[i] = types.StringValue(port)
+		}
+		m.Ports = types.SetValueMust(types.StringType, vals)
+	} else {
+		m.Ports = types.SetValueMust(types.StringType, []attr.Value{})
+	}
+}

--- a/internal/provider/port_group_resource_test.go
+++ b/internal/provider/port_group_resource_test.go
@@ -1,0 +1,417 @@
+package provider
+
+import (
+	"fmt"
+	"regexp"
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-framework/attr"
+	"github.com/hashicorp/terraform-plugin-framework/types"
+	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
+	"github.com/hashicorp/terraform-plugin-testing/terraform"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"github.com/ubiquiti-community/go-unifi/unifi"
+)
+
+// ---------------------------------------------------------------------------
+// Unit tests
+// ---------------------------------------------------------------------------
+
+func TestPortGroupModelToAPI(t *testing.T) {
+	r := &portGroupResource{}
+	ctx := t.Context()
+
+	t.Run("basic ports", func(t *testing.T) {
+		model := &portGroupResourceModel{
+			Name: types.StringValue("Web Ports"),
+			Ports: types.SetValueMust(types.StringType, []attr.Value{
+				types.StringValue("80"),
+				types.StringValue("443"),
+			}),
+		}
+
+		group, diags := r.modelToAPI(ctx, model)
+		require.False(t, diags.HasError())
+
+		assert.Equal(t, "Web Ports", group.Name)
+		assert.Equal(t, "port-group", group.GroupType)
+		assert.Len(t, group.GroupMembers, 2)
+		assert.Contains(t, group.GroupMembers, "80")
+		assert.Contains(t, group.GroupMembers, "443")
+	})
+
+	t.Run("port range", func(t *testing.T) {
+		model := &portGroupResourceModel{
+			Name: types.StringValue("High Ports"),
+			Ports: types.SetValueMust(types.StringType, []attr.Value{
+				types.StringValue("8080-8090"),
+			}),
+		}
+
+		group, diags := r.modelToAPI(ctx, model)
+		require.False(t, diags.HasError())
+
+		assert.Equal(t, "High Ports", group.Name)
+		assert.Equal(t, "port-group", group.GroupType)
+		assert.Equal(t, []string{"8080-8090"}, group.GroupMembers)
+	})
+
+	t.Run("type is always port-group", func(t *testing.T) {
+		model := &portGroupResourceModel{
+			Name:  types.StringValue("Test"),
+			Ports: types.SetValueMust(types.StringType, []attr.Value{types.StringValue("22")}),
+		}
+
+		group, diags := r.modelToAPI(ctx, model)
+		require.False(t, diags.HasError())
+		assert.Equal(t, "port-group", group.GroupType)
+	})
+}
+
+func TestPortGroupAPIToModel(t *testing.T) {
+	r := &portGroupResource{}
+
+	t.Run("populated group", func(t *testing.T) {
+		group := &unifi.FirewallGroup{
+			ID:           "abc123",
+			Name:         "Web Ports",
+			GroupType:    "port-group",
+			GroupMembers: []string{"80", "443", "8080"},
+		}
+
+		var model portGroupResourceModel
+		r.apiToModel(group, &model, "default")
+
+		assert.Equal(t, "abc123", model.ID.ValueString())
+		assert.Equal(t, "default", model.Site.ValueString())
+		assert.Equal(t, "Web Ports", model.Name.ValueString())
+		assert.Equal(t, 3, len(model.Ports.Elements()))
+	})
+
+	t.Run("nil members returns empty set", func(t *testing.T) {
+		group := &unifi.FirewallGroup{
+			ID:           "xyz",
+			Name:         "Empty",
+			GroupType:    "port-group",
+			GroupMembers: nil,
+		}
+
+		var model portGroupResourceModel
+		r.apiToModel(group, &model, "default")
+
+		assert.False(t, model.Ports.IsNull())
+		assert.Equal(t, 0, len(model.Ports.Elements()))
+	})
+}
+
+func TestPortGroupApplyPlanToState(t *testing.T) {
+	r := &portGroupResource{}
+
+	t.Run("name update preserves ports", func(t *testing.T) {
+		state := &portGroupResourceModel{
+			Name: types.StringValue("Old Name"),
+			Ports: types.SetValueMust(types.StringType, []attr.Value{
+				types.StringValue("80"),
+			}),
+		}
+
+		plan := &portGroupResourceModel{
+			Name:  types.StringValue("New Name"),
+			Ports: types.SetNull(types.StringType),
+		}
+
+		r.applyPlanToState(plan, state)
+
+		assert.Equal(t, "New Name", state.Name.ValueString())
+		assert.Equal(t, 1, len(state.Ports.Elements()))
+	})
+
+	t.Run("ports update preserves name", func(t *testing.T) {
+		state := &portGroupResourceModel{
+			Name: types.StringValue("My Group"),
+			Ports: types.SetValueMust(types.StringType, []attr.Value{
+				types.StringValue("80"),
+			}),
+		}
+
+		plan := &portGroupResourceModel{
+			Name: types.StringNull(),
+			Ports: types.SetValueMust(types.StringType, []attr.Value{
+				types.StringValue("80"),
+				types.StringValue("443"),
+			}),
+		}
+
+		r.applyPlanToState(plan, state)
+
+		assert.Equal(t, "My Group", state.Name.ValueString())
+		assert.Equal(t, 2, len(state.Ports.Elements()))
+	})
+}
+
+// ---------------------------------------------------------------------------
+// Acceptance tests
+// ---------------------------------------------------------------------------
+
+func TestAccPortGroup_basic(t *testing.T) {
+	name := fmt.Sprintf("tfacc-pg-%s", randomSuffix())
+	resource.Test(t, resource.TestCase{
+		PreCheck:                 func() { preCheck(t) },
+		ProtoV6ProviderFactories: testAccProtoV6ProviderFactories,
+		Steps: []resource.TestStep{
+			{
+				Config: fmt.Sprintf(`
+resource "terrifi_port_group" "test" {
+  name  = %q
+  ports = ["80", "443"]
+}
+`, name),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr("terrifi_port_group.test", "name", name),
+					resource.TestCheckResourceAttr("terrifi_port_group.test", "ports.#", "2"),
+					resource.TestCheckResourceAttr("terrifi_port_group.test", "site", "default"),
+					resource.TestCheckResourceAttrSet("terrifi_port_group.test", "id"),
+				),
+			},
+		},
+	})
+}
+
+func TestAccPortGroup_updatePorts(t *testing.T) {
+	name := fmt.Sprintf("tfacc-pg-upd-%s", randomSuffix())
+	resource.Test(t, resource.TestCase{
+		PreCheck:                 func() { preCheck(t) },
+		ProtoV6ProviderFactories: testAccProtoV6ProviderFactories,
+		Steps: []resource.TestStep{
+			{
+				Config: fmt.Sprintf(`
+resource "terrifi_port_group" "test" {
+  name  = %q
+  ports = ["80", "443"]
+}
+`, name),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr("terrifi_port_group.test", "ports.#", "2"),
+				),
+			},
+			{
+				Config: fmt.Sprintf(`
+resource "terrifi_port_group" "test" {
+  name  = %q
+  ports = ["80", "443", "8080", "8443"]
+}
+`, name),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr("terrifi_port_group.test", "ports.#", "4"),
+				),
+			},
+		},
+	})
+}
+
+func TestAccPortGroup_removePorts(t *testing.T) {
+	name := fmt.Sprintf("tfacc-pg-rm-%s", randomSuffix())
+	resource.Test(t, resource.TestCase{
+		PreCheck:                 func() { preCheck(t) },
+		ProtoV6ProviderFactories: testAccProtoV6ProviderFactories,
+		Steps: []resource.TestStep{
+			{
+				Config: fmt.Sprintf(`
+resource "terrifi_port_group" "test" {
+  name  = %q
+  ports = ["80", "443", "8080", "8443"]
+}
+`, name),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr("terrifi_port_group.test", "ports.#", "4"),
+				),
+			},
+			{
+				Config: fmt.Sprintf(`
+resource "terrifi_port_group" "test" {
+  name  = %q
+  ports = ["443"]
+}
+`, name),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr("terrifi_port_group.test", "ports.#", "1"),
+				),
+			},
+		},
+	})
+}
+
+func TestAccPortGroup_updateName(t *testing.T) {
+	name1 := fmt.Sprintf("tfacc-pg-n1-%s", randomSuffix())
+	name2 := fmt.Sprintf("tfacc-pg-n2-%s", randomSuffix())
+	resource.Test(t, resource.TestCase{
+		PreCheck:                 func() { preCheck(t) },
+		ProtoV6ProviderFactories: testAccProtoV6ProviderFactories,
+		Steps: []resource.TestStep{
+			{
+				Config: fmt.Sprintf(`
+resource "terrifi_port_group" "test" {
+  name  = %q
+  ports = ["80"]
+}
+`, name1),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr("terrifi_port_group.test", "name", name1),
+				),
+			},
+			{
+				Config: fmt.Sprintf(`
+resource "terrifi_port_group" "test" {
+  name  = %q
+  ports = ["80"]
+}
+`, name2),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr("terrifi_port_group.test", "name", name2),
+				),
+			},
+		},
+	})
+}
+
+func TestAccPortGroup_portRange(t *testing.T) {
+	name := fmt.Sprintf("tfacc-pg-range-%s", randomSuffix())
+	resource.Test(t, resource.TestCase{
+		PreCheck:                 func() { preCheck(t) },
+		ProtoV6ProviderFactories: testAccProtoV6ProviderFactories,
+		Steps: []resource.TestStep{
+			{
+				Config: fmt.Sprintf(`
+resource "terrifi_port_group" "test" {
+  name  = %q
+  ports = ["80", "8080-8090", "443"]
+}
+`, name),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr("terrifi_port_group.test", "name", name),
+					resource.TestCheckResourceAttr("terrifi_port_group.test", "ports.#", "3"),
+				),
+			},
+		},
+	})
+}
+
+func TestAccPortGroup_manyPorts(t *testing.T) {
+	name := fmt.Sprintf("tfacc-pg-many-%s", randomSuffix())
+	resource.Test(t, resource.TestCase{
+		PreCheck:                 func() { preCheck(t) },
+		ProtoV6ProviderFactories: testAccProtoV6ProviderFactories,
+		Steps: []resource.TestStep{
+			{
+				Config: fmt.Sprintf(`
+resource "terrifi_port_group" "test" {
+  name  = %q
+  ports = ["22", "53", "80", "443", "993", "995", "3389", "5060", "8080", "8443"]
+}
+`, name),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr("terrifi_port_group.test", "ports.#", "10"),
+				),
+			},
+		},
+	})
+}
+
+func TestAccPortGroup_import(t *testing.T) {
+	name := fmt.Sprintf("tfacc-pg-imp-%s", randomSuffix())
+	resource.Test(t, resource.TestCase{
+		PreCheck:                 func() { preCheck(t) },
+		ProtoV6ProviderFactories: testAccProtoV6ProviderFactories,
+		Steps: []resource.TestStep{
+			{
+				Config: fmt.Sprintf(`
+resource "terrifi_port_group" "test" {
+  name  = %q
+  ports = ["80", "443"]
+}
+`, name),
+			},
+			{
+				ResourceName:      "terrifi_port_group.test",
+				ImportState:       true,
+				ImportStateVerify: true,
+			},
+		},
+	})
+}
+
+func TestAccPortGroup_importSiteID(t *testing.T) {
+	name := fmt.Sprintf("tfacc-pg-impsid-%s", randomSuffix())
+	resource.Test(t, resource.TestCase{
+		PreCheck:                 func() { preCheck(t) },
+		ProtoV6ProviderFactories: testAccProtoV6ProviderFactories,
+		Steps: []resource.TestStep{
+			{
+				Config: fmt.Sprintf(`
+resource "terrifi_port_group" "test" {
+  name  = %q
+  ports = ["80", "443"]
+}
+`, name),
+			},
+			{
+				ResourceName:      "terrifi_port_group.test",
+				ImportState:       true,
+				ImportStateVerify: true,
+				ImportStateIdFunc: func(s *terraform.State) (string, error) {
+					rs := s.RootModule().Resources["terrifi_port_group.test"]
+					if rs == nil {
+						return "", fmt.Errorf("resource not found in state")
+					}
+					return fmt.Sprintf("%s:%s", rs.Primary.Attributes["site"], rs.Primary.Attributes["id"]), nil
+				},
+			},
+		},
+	})
+}
+
+func TestAccPortGroup_dataSource(t *testing.T) {
+	name := fmt.Sprintf("tfacc-pg-ds-%s", randomSuffix())
+	resource.Test(t, resource.TestCase{
+		PreCheck:                 func() { preCheck(t) },
+		ProtoV6ProviderFactories: testAccProtoV6ProviderFactories,
+		Steps: []resource.TestStep{
+			{
+				Config: fmt.Sprintf(`
+resource "terrifi_port_group" "test" {
+  name  = %q
+  ports = ["80", "443", "8080"]
+}
+
+data "terrifi_port_group" "lookup" {
+  name = terrifi_port_group.test.name
+}
+`, name),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr("data.terrifi_port_group.lookup", "name", name),
+					resource.TestCheckResourceAttr("data.terrifi_port_group.lookup", "ports.#", "3"),
+					resource.TestCheckResourceAttrSet("data.terrifi_port_group.lookup", "id"),
+					resource.TestCheckResourceAttr("data.terrifi_port_group.lookup", "site", "default"),
+				),
+			},
+		},
+	})
+}
+
+func TestAccPortGroup_dataSourceNotFound(t *testing.T) {
+	resource.Test(t, resource.TestCase{
+		PreCheck:                 func() { preCheck(t) },
+		ProtoV6ProviderFactories: testAccProtoV6ProviderFactories,
+		Steps: []resource.TestStep{
+			{
+				Config: `
+data "terrifi_port_group" "missing" {
+  name = "this-port-group-does-not-exist-at-all"
+}
+`,
+				ExpectError: regexp.MustCompile(`Port Group Not Found`),
+			},
+		},
+	})
+}

--- a/internal/provider/provider.go
+++ b/internal/provider/provider.go
@@ -240,6 +240,7 @@ func (p *terrifiProvider) Resources(_ context.Context) []func() resource.Resourc
 		NewFirewallPolicyOrderResource,
 		NewFirewallZoneResource,
 		NewNetworkResource,
+		NewPortGroupResource,
 		NewWLANResource,
 	}
 }
@@ -249,6 +250,7 @@ func (p *terrifiProvider) Resources(_ context.Context) []func() resource.Resourc
 func (p *terrifiProvider) DataSources(_ context.Context) []func() datasource.DataSource {
 	return []func() datasource.DataSource{
 		NewDeviceDataSource,
+		NewPortGroupDataSource,
 	}
 }
 


### PR DESCRIPTION
## Summary

- Adds `terrifi_port_group` resource for managing UniFi port groups (named collections of port numbers/ranges used in firewall policies)
- Adds `terrifi_port_group` data source for looking up existing port groups by name
- Adds import generation support via `terrifi generate-imports terrifi_port_group`
- Adds docs for both the resource and data source

## Test plan

- [ ] Unit tests for model-to-API conversion in `port_group_resource_test.go`
- [ ] Acceptance tests covering create, update, delete, and import lifecycle
- [ ] Verify `terrifi generate-imports terrifi_port_group` produces valid HCL

🤖 Generated with [Claude Code](https://claude.com/claude-code)