### PR TITLE
Add CUSTOM as a valid schedule mode for firewall policies

### DIFF
--- a/docs/resources/firewall_policy.md
+++ b/docs/resources/firewall_policy.md
@@ -127,6 +127,34 @@ resource "terrifi_firewall_policy" "weekday_block" {
 }
 ```
 
+### Custom schedule (date range with selected days)
+
+Use `CUSTOM` mode to restrict a policy to specific days within a date range. Both `date_start` and `date_end` are required.
+
+```terraform
+resource "terrifi_firewall_policy" "holiday_block" {
+  name   = "Block during holiday hours"
+  action = "BLOCK"
+
+  source {
+    zone_id = terrifi_firewall_zone.guest.id
+  }
+
+  destination {
+    zone_id = terrifi_firewall_zone.internal.id
+  }
+
+  schedule {
+    mode             = "CUSTOM"
+    date_start       = "2030-12-20"
+    date_end         = "2031-01-05"
+    time_range_start = "09:00"
+    time_range_end   = "17:00"
+    repeat_on_days   = ["mon", "wed", "fri"]
+  }
+}
+```
+
 ## Schema
 
 ### Required
@@ -172,8 +200,10 @@ At most one of `ips`, `mac_addresses`, `network_ids`, or `device_ids` may be set
 
 ### Schedule
 
-- `mode` (String, Required) — Schedule mode. Valid values: `ALWAYS`, `EVERY_DAY`, `EVERY_WEEK`, `ONE_TIME_ONLY`.
-- `date` (String) — Date for one-time schedules.
+- `mode` (String, Required) — Schedule mode. Valid values: `ALWAYS`, `EVERY_DAY`, `EVERY_WEEK`, `ONE_TIME_ONLY`, `CUSTOM`.
+- `date` (String) — Date for one-time schedules (e.g. `2030-01-01`). Used with `ONE_TIME_ONLY` mode.
+- `date_start` (String) — Start date of the schedule range (e.g. `2030-01-01`). Required when `mode` is `CUSTOM`.
+- `date_end` (String) — End date of the schedule range (e.g. `2030-12-31`). Required when `mode` is `CUSTOM`.
 - `time_all_day` (Boolean) — Whether the schedule applies all day.
 - `time_range_start` (String) — Start time (e.g. `08:00`).
 - `time_range_end` (String) — End time (e.g. `17:00`).

--- a/internal/provider/firewall_policy_api.go
+++ b/internal/provider/firewall_policy_api.go
@@ -86,8 +86,8 @@ type firewallPolicyScheduleRequest struct {
 	TimeRangeStart string   `json:"time_range_start,omitempty"`
 	TimeRangeEnd   string   `json:"time_range_end,omitempty"`
 	RepeatOnDays   []string `json:"repeat_on_days,omitempty"`
-	DateRangeStart string   `json:"date_range_start,omitempty"`
-	DateRangeEnd   string   `json:"date_range_end,omitempty"`
+	DateStart string `json:"date_start,omitempty"`
+	DateEnd   string `json:"date_end,omitempty"`
 }
 
 // firewallPolicyFull wraps *unifi.FirewallPolicy with the raw schedule from the

--- a/internal/provider/firewall_policy_api.go
+++ b/internal/provider/firewall_policy_api.go
@@ -86,12 +86,24 @@ type firewallPolicyScheduleRequest struct {
 	TimeRangeStart string   `json:"time_range_start,omitempty"`
 	TimeRangeEnd   string   `json:"time_range_end,omitempty"`
 	RepeatOnDays   []string `json:"repeat_on_days,omitempty"`
+	DateRangeStart string   `json:"date_range_start,omitempty"`
+	DateRangeEnd   string   `json:"date_range_end,omitempty"`
+}
+
+// firewallPolicyFull wraps *unifi.FirewallPolicy with the raw schedule from the
+// API response, preserving fields (date_range_start, date_range_end) that are not
+// present in the SDK's FirewallPolicySchedule struct.
+type firewallPolicyFull struct {
+	*unifi.FirewallPolicy
+	RawSchedule *firewallPolicyScheduleRequest
 }
 
 // CreateFirewallPolicy creates a firewall policy via the v2 API, bypassing the
-// SDK to control boolean serialization.
-func (c *Client) CreateFirewallPolicy(ctx context.Context, site string, d *unifi.FirewallPolicy) (*unifi.FirewallPolicy, error) {
-	payload := buildFirewallPolicyCreateRequest(d)
+// SDK to control boolean serialization. schedOverride, when non-nil, is used as
+// the schedule payload instead of deriving it from d.Schedule, allowing callers
+// to include fields (e.g. date_range_start, date_range_end) not in the SDK struct.
+func (c *Client) CreateFirewallPolicy(ctx context.Context, site string, d *unifi.FirewallPolicy, schedOverride *firewallPolicyScheduleRequest) (*firewallPolicyFull, error) {
+	payload := buildFirewallPolicyCreateRequest(d, schedOverride)
 
 	var result firewallPolicyResponse
 	err := c.doV2Request(ctx, http.MethodPost,
@@ -100,13 +112,14 @@ func (c *Client) CreateFirewallPolicy(ctx context.Context, site string, d *unifi
 	if err != nil {
 		return nil, err
 	}
-	return result.toSDK(), nil
+	return result.toFull(), nil
 }
 
 // UpdateFirewallPolicy updates a firewall policy via the v2 API, bypassing the
-// SDK to include _id in the PUT body and control boolean serialization.
-func (c *Client) UpdateFirewallPolicy(ctx context.Context, site string, d *unifi.FirewallPolicy) (*unifi.FirewallPolicy, error) {
-	create := buildFirewallPolicyCreateRequest(d)
+// SDK to include _id in the PUT body and control boolean serialization. schedOverride,
+// when non-nil, is used as the schedule payload instead of deriving it from d.Schedule.
+func (c *Client) UpdateFirewallPolicy(ctx context.Context, site string, d *unifi.FirewallPolicy, schedOverride *firewallPolicyScheduleRequest) (*firewallPolicyFull, error) {
+	create := buildFirewallPolicyCreateRequest(d, schedOverride)
 	payload := firewallPolicyUpdateRequest{
 		ID:                          d.ID,
 		firewallPolicyCreateRequest: create,
@@ -119,7 +132,7 @@ func (c *Client) UpdateFirewallPolicy(ctx context.Context, site string, d *unifi
 	if err != nil {
 		return nil, err
 	}
-	return result.toSDK(), nil
+	return result.toFull(), nil
 }
 
 // DeleteFirewallPolicy deletes a firewall policy via the v2 API, bypassing the
@@ -154,7 +167,7 @@ func (c *Client) ListFirewallPolicies(ctx context.Context, site string) ([]*unif
 // *int64, but the v2 API returns `port` as a JSON string (e.g. "443"). The SDK
 // fails to unmarshal this. When the SDK fixes the port field type (or adds a
 // custom unmarshaler), this can be replaced with c.ApiClient.GetFirewallPolicy().
-func (c *Client) GetFirewallPolicy(ctx context.Context, site string, id string) (*unifi.FirewallPolicy, error) {
+func (c *Client) GetFirewallPolicy(ctx context.Context, site string, id string) (*firewallPolicyFull, error) {
 	var rawPolicies []firewallPolicyResponse
 	err := c.doV2Request(ctx, http.MethodGet,
 		fmt.Sprintf("%s%s/v2/api/site/%s/firewall-policies", c.BaseURL, c.APIPath, site),
@@ -165,7 +178,7 @@ func (c *Client) GetFirewallPolicy(ctx context.Context, site string, id string) 
 
 	for _, raw := range rawPolicies {
 		if raw.ID == id {
-			return raw.toSDK(), nil
+			return raw.toFull(), nil
 		}
 	}
 	return nil, &unifi.NotFoundError{}
@@ -205,6 +218,13 @@ type firewallPolicyEndpointResponse struct {
 	PortGroupID        string          `json:"port_group_id"`
 	MatchOppositePorts bool            `json:"match_opposite_ports"`
 	MatchOppositeIPs   bool            `json:"match_opposite_ips"`
+}
+
+func (r *firewallPolicyResponse) toFull() *firewallPolicyFull {
+	return &firewallPolicyFull{
+		FirewallPolicy: r.toSDK(),
+		RawSchedule:    r.Schedule,
+	}
 }
 
 func (r *firewallPolicyResponse) toSDK() *unifi.FirewallPolicy {
@@ -307,7 +327,7 @@ func (ep *firewallPolicyEndpointResponse) resolveIPs() []string {
 	return ep.IPs
 }
 
-func buildFirewallPolicyCreateRequest(d *unifi.FirewallPolicy) firewallPolicyCreateRequest {
+func buildFirewallPolicyCreateRequest(d *unifi.FirewallPolicy, schedOverride *firewallPolicyScheduleRequest) firewallPolicyCreateRequest {
 	req := firewallPolicyCreateRequest{
 		Name:                d.Name,
 		Description:         d.Description,
@@ -341,7 +361,9 @@ func buildFirewallPolicyCreateRequest(d *unifi.FirewallPolicy) firewallPolicyCre
 		req.Destination = buildEndpointRequest(d.Destination.ZoneID, d.Destination.MatchingTarget, d.Destination.IPs, d.Destination.PortMatchingType, d.Destination.Port, d.Destination.PortGroupID, d.Destination.MatchOppositePorts, d.Destination.MatchOppositeIPs)
 	}
 
-	if d.Schedule != nil {
+	if schedOverride != nil {
+		req.Schedule = schedOverride
+	} else if d.Schedule != nil {
 		sched := &firewallPolicyScheduleRequest{
 			Mode:           d.Schedule.Mode,
 			Date:           d.Schedule.Date,

--- a/internal/provider/firewall_policy_resource.go
+++ b/internal/provider/firewall_policy_resource.go
@@ -510,16 +510,20 @@ func (r *firewallPolicyResource) ModifyPlan(
 // ---------------------------------------------------------------------------
 
 func (r *firewallPolicyResource) applyPlanToState(plan, state *firewallPolicyResourceModel) {
-	if !plan.Name.IsNull() && !plan.Name.IsUnknown() {
+	if !plan.Name.IsUnknown() {
 		state.Name = plan.Name
 	}
-	if !plan.Description.IsNull() && !plan.Description.IsUnknown() {
+	// For optional-only fields (no Computed/Default), null means the user removed
+	// the field. Propagate null so the API receives a cleared value instead of the
+	// stale state value, which would cause a "provider produced inconsistent result"
+	// error when the API echoes the old value back.
+	if !plan.Description.IsUnknown() {
 		state.Description = plan.Description
 	}
 	if !plan.Enabled.IsNull() && !plan.Enabled.IsUnknown() {
 		state.Enabled = plan.Enabled
 	}
-	if !plan.Action.IsNull() && !plan.Action.IsUnknown() {
+	if !plan.Action.IsUnknown() {
 		state.Action = plan.Action
 	}
 	if !plan.IPVersion.IsNull() && !plan.IPVersion.IsUnknown() {
@@ -531,28 +535,28 @@ func (r *firewallPolicyResource) applyPlanToState(plan, state *firewallPolicyRes
 	if !plan.ConnectionStateType.IsNull() && !plan.ConnectionStateType.IsUnknown() {
 		state.ConnectionStateType = plan.ConnectionStateType
 	}
-	if !plan.ConnectionStates.IsNull() && !plan.ConnectionStates.IsUnknown() {
+	if !plan.ConnectionStates.IsUnknown() {
 		state.ConnectionStates = plan.ConnectionStates
 	}
-	if !plan.MatchIPSec.IsNull() && !plan.MatchIPSec.IsUnknown() {
+	if !plan.MatchIPSec.IsUnknown() {
 		state.MatchIPSec = plan.MatchIPSec
 	}
-	if !plan.Logging.IsNull() && !plan.Logging.IsUnknown() {
+	if !plan.Logging.IsUnknown() {
 		state.Logging = plan.Logging
 	}
-	if !plan.CreateAllowRespond.IsNull() && !plan.CreateAllowRespond.IsUnknown() {
+	if !plan.CreateAllowRespond.IsUnknown() {
 		state.CreateAllowRespond = plan.CreateAllowRespond
 	}
 	if !plan.Index.IsNull() && !plan.Index.IsUnknown() {
 		state.Index = plan.Index
 	}
-	if !plan.Source.IsNull() && !plan.Source.IsUnknown() {
+	if !plan.Source.IsUnknown() {
 		state.Source = plan.Source
 	}
-	if !plan.Destination.IsNull() && !plan.Destination.IsUnknown() {
+	if !plan.Destination.IsUnknown() {
 		state.Destination = plan.Destination
 	}
-	if !plan.Schedule.IsNull() && !plan.Schedule.IsUnknown() {
+	if !plan.Schedule.IsUnknown() {
 		state.Schedule = plan.Schedule
 	}
 }

--- a/internal/provider/firewall_policy_resource.go
+++ b/internal/provider/firewall_policy_resource.go
@@ -284,10 +284,10 @@ func (r *firewallPolicyResource) Schema(
 				MarkdownDescription: "Schedule configuration for when this policy is active.",
 				Attributes: map[string]schema.Attribute{
 					"mode": schema.StringAttribute{
-						MarkdownDescription: "Schedule mode. Valid values: `ALWAYS`, `EVERY_DAY`, `EVERY_WEEK`, `ONE_TIME_ONLY`.",
+						MarkdownDescription: "Schedule mode. Valid values: `ALWAYS`, `EVERY_DAY`, `EVERY_WEEK`, `ONE_TIME_ONLY`, `CUSTOM`.",
 						Optional:            true,
 						Validators: []validator.String{
-							stringvalidator.OneOf("ALWAYS", "EVERY_DAY", "EVERY_WEEK", "ONE_TIME_ONLY"),
+							stringvalidator.OneOf("ALWAYS", "EVERY_DAY", "EVERY_WEEK", "ONE_TIME_ONLY", "CUSTOM"),
 						},
 					},
 					"date": schema.StringAttribute{

--- a/internal/provider/firewall_policy_resource.go
+++ b/internal/provider/firewall_policy_resource.go
@@ -286,6 +286,7 @@ func (r *firewallPolicyResource) Schema(
 
 			"schedule": schema.SingleNestedBlock{
 				MarkdownDescription: "Schedule configuration for when this policy is active.",
+				Validators:          []validator.Object{scheduleCustomRequiresDatesValidator{}},
 				Attributes: map[string]schema.Attribute{
 					"mode": schema.StringAttribute{
 						MarkdownDescription: "Schedule mode. Valid values: `ALWAYS`, `EVERY_DAY`, `EVERY_WEEK`, `ONE_TIME_ONLY`, `CUSTOM`.",
@@ -926,6 +927,46 @@ func stringValueOrNull(s string) types.String {
 // isDefaultSchedule returns true when the schedule is the API's default
 // (mode=ALWAYS with no other fields set). We treat this as "no schedule
 // configured" so that omitting the schedule block doesn't cause drift.
+// scheduleCustomRequiresDatesValidator enforces that date_start and date_end are
+// set whenever schedule mode is CUSTOM.
+type scheduleCustomRequiresDatesValidator struct{}
+
+func (v scheduleCustomRequiresDatesValidator) Description(_ context.Context) string {
+	return "When mode is CUSTOM, date_start and date_end are required."
+}
+
+func (v scheduleCustomRequiresDatesValidator) MarkdownDescription(_ context.Context) string {
+	return "When `mode` is `CUSTOM`, `date_start` and `date_end` are required."
+}
+
+func (v scheduleCustomRequiresDatesValidator) ValidateObject(ctx context.Context, req validator.ObjectRequest, resp *validator.ObjectResponse) {
+	if req.ConfigValue.IsNull() || req.ConfigValue.IsUnknown() {
+		return
+	}
+	var sched firewallPolicyScheduleModel
+	resp.Diagnostics.Append(req.ConfigValue.As(ctx, &sched, basetypes.ObjectAsOptions{})...)
+	if resp.Diagnostics.HasError() {
+		return
+	}
+	if sched.Mode.ValueString() != "CUSTOM" {
+		return
+	}
+	if sched.DateStart.IsNull() || sched.DateStart.ValueString() == "" {
+		resp.Diagnostics.AddAttributeError(
+			req.Path.AtName("date_start"),
+			"Missing Required Attribute",
+			"date_start is required when schedule mode is CUSTOM.",
+		)
+	}
+	if sched.DateEnd.IsNull() || sched.DateEnd.ValueString() == "" {
+		resp.Diagnostics.AddAttributeError(
+			req.Path.AtName("date_end"),
+			"Missing Required Attribute",
+			"date_end is required when schedule mode is CUSTOM.",
+		)
+	}
+}
+
 func isDefaultSchedule(s *firewallPolicyScheduleRequest) bool {
 	timeAllDay := s.TimeAllDay != nil && *s.TimeAllDay
 	return s.Mode == "ALWAYS" &&

--- a/internal/provider/firewall_policy_resource.go
+++ b/internal/provider/firewall_policy_resource.go
@@ -74,8 +74,8 @@ type firewallPolicyScheduleModel struct {
 	TimeRangeStart types.String `tfsdk:"time_range_start"`
 	TimeRangeEnd   types.String `tfsdk:"time_range_end"`
 	RepeatOnDays   types.Set    `tfsdk:"repeat_on_days"`
-	DateRangeStart types.String `tfsdk:"date_range_start"`
-	DateRangeEnd   types.String `tfsdk:"date_range_end"`
+	DateStart      types.String `tfsdk:"date_start"`
+	DateEnd        types.String `tfsdk:"date_end"`
 }
 
 // endpointAttrTypes defines the attribute types for source/destination nested objects.
@@ -100,8 +100,8 @@ var scheduleAttrTypes = map[string]attr.Type{
 	"time_range_start": types.StringType,
 	"time_range_end":   types.StringType,
 	"repeat_on_days":   types.SetType{ElemType: types.StringType},
-	"date_range_start": types.StringType,
-	"date_range_end":   types.StringType,
+	"date_start":       types.StringType,
+	"date_end":         types.StringType,
 }
 
 func (r *firewallPolicyResource) Metadata(
@@ -315,11 +315,11 @@ func (r *firewallPolicyResource) Schema(
 						ElementType:         types.StringType,
 						Optional:            true,
 					},
-					"date_range_start": schema.StringAttribute{
+					"date_start": schema.StringAttribute{
 						MarkdownDescription: "Start date of the schedule range (e.g. `2026-01-01`). Required for `CUSTOM` mode.",
 						Optional:            true,
 					},
-					"date_range_end": schema.StringAttribute{
+					"date_end": schema.StringAttribute{
 						MarkdownDescription: "End date of the schedule range (e.g. `2026-12-31`). Required for `CUSTOM` mode.",
 						Optional:            true,
 					},
@@ -715,8 +715,8 @@ func scheduleModelToRequest(ctx context.Context, m *firewallPolicyResourceModel)
 		Date:           sched.Date.ValueString(),
 		TimeRangeStart: sched.TimeRangeStart.ValueString(),
 		TimeRangeEnd:   sched.TimeRangeEnd.ValueString(),
-		DateRangeStart: sched.DateRangeStart.ValueString(),
-		DateRangeEnd:   sched.DateRangeEnd.ValueString(),
+		DateStart:      sched.DateStart.ValueString(),
+		DateEnd:        sched.DateEnd.ValueString(),
 	}
 	if sched.TimeAllDay.ValueBool() {
 		req.TimeAllDay = boolPtr(true)
@@ -899,8 +899,8 @@ func scheduleAPIToModel(sched *firewallPolicyScheduleRequest) types.Object {
 		"time_all_day":     boolValueOrNull(timeAllDay),
 		"time_range_start": stringValueOrNull(sched.TimeRangeStart),
 		"time_range_end":   stringValueOrNull(sched.TimeRangeEnd),
-		"date_range_start": stringValueOrNull(sched.DateRangeStart),
-		"date_range_end":   stringValueOrNull(sched.DateRangeEnd),
+		"date_start": stringValueOrNull(sched.DateStart),
+		"date_end":   stringValueOrNull(sched.DateEnd),
 	}
 
 	if sched.RepeatOnDays != nil {
@@ -934,6 +934,6 @@ func isDefaultSchedule(s *firewallPolicyScheduleRequest) bool {
 		s.TimeRangeStart == "" &&
 		s.TimeRangeEnd == "" &&
 		len(s.RepeatOnDays) == 0 &&
-		s.DateRangeStart == "" &&
-		s.DateRangeEnd == ""
+		s.DateStart == "" &&
+		s.DateEnd == ""
 }

--- a/internal/provider/firewall_policy_resource.go
+++ b/internal/provider/firewall_policy_resource.go
@@ -74,6 +74,8 @@ type firewallPolicyScheduleModel struct {
 	TimeRangeStart types.String `tfsdk:"time_range_start"`
 	TimeRangeEnd   types.String `tfsdk:"time_range_end"`
 	RepeatOnDays   types.Set    `tfsdk:"repeat_on_days"`
+	DateRangeStart types.String `tfsdk:"date_range_start"`
+	DateRangeEnd   types.String `tfsdk:"date_range_end"`
 }
 
 // endpointAttrTypes defines the attribute types for source/destination nested objects.
@@ -98,6 +100,8 @@ var scheduleAttrTypes = map[string]attr.Type{
 	"time_range_start": types.StringType,
 	"time_range_end":   types.StringType,
 	"repeat_on_days":   types.SetType{ElemType: types.StringType},
+	"date_range_start": types.StringType,
+	"date_range_end":   types.StringType,
 }
 
 func (r *firewallPolicyResource) Metadata(
@@ -311,6 +315,14 @@ func (r *firewallPolicyResource) Schema(
 						ElementType:         types.StringType,
 						Optional:            true,
 					},
+					"date_range_start": schema.StringAttribute{
+						MarkdownDescription: "Start date of the schedule range (e.g. `2026-01-01`). Required for `CUSTOM` mode.",
+						Optional:            true,
+					},
+					"date_range_end": schema.StringAttribute{
+						MarkdownDescription: "End date of the schedule range (e.g. `2026-12-31`). Required for `CUSTOM` mode.",
+						Optional:            true,
+					},
 				},
 			},
 		},
@@ -351,8 +363,9 @@ func (r *firewallPolicyResource) Create(
 
 	site := r.client.SiteOrDefault(plan.Site)
 	policy := r.modelToAPI(ctx, &plan)
+	schedReq := scheduleModelToRequest(ctx, &plan)
 
-	created, err := r.client.CreateFirewallPolicy(ctx, site, policy)
+	created, err := r.client.CreateFirewallPolicy(ctx, site, policy, schedReq)
 	if err != nil {
 		resp.Diagnostics.AddError("Error Creating Firewall Policy", err.Error())
 		return
@@ -375,7 +388,7 @@ func (r *firewallPolicyResource) Read(
 
 	site := r.client.SiteOrDefault(state.Site)
 
-	policy, err := r.client.GetFirewallPolicy(ctx, site, state.ID.ValueString())
+	full, err := r.client.GetFirewallPolicy(ctx, site, state.ID.ValueString())
 	if err != nil {
 		if _, ok := err.(*unifi.NotFoundError); ok {
 			resp.State.RemoveResource(ctx)
@@ -388,7 +401,7 @@ func (r *firewallPolicyResource) Read(
 		return
 	}
 
-	r.apiToModel(policy, &state, site)
+	r.apiToModel(full, &state, site)
 	resp.Diagnostics.Append(resp.State.Set(ctx, &state)...)
 }
 
@@ -409,8 +422,9 @@ func (r *firewallPolicyResource) Update(
 	site := r.client.SiteOrDefault(state.Site)
 	policy := r.modelToAPI(ctx, &state)
 	policy.ID = state.ID.ValueString()
+	schedReq := scheduleModelToRequest(ctx, &state)
 
-	updated, err := r.client.UpdateFirewallPolicy(ctx, site, policy)
+	updated, err := r.client.UpdateFirewallPolicy(ctx, site, policy, schedReq)
 	if err != nil {
 		resp.Diagnostics.AddError("Error Updating Firewall Policy", err.Error())
 		return
@@ -686,7 +700,37 @@ func scheduleModelToAPI(ctx context.Context, m *firewallPolicyScheduleModel) *un
 	return sched
 }
 
-func (r *firewallPolicyResource) apiToModel(policy *unifi.FirewallPolicy, m *firewallPolicyResourceModel, site string) {
+// scheduleModelToRequest builds a firewallPolicyScheduleRequest from the top-level
+// resource model. Returns nil when the model has no schedule block configured.
+// This preserves fields (DateRangeStart, DateRangeEnd) not present in the SDK struct.
+func scheduleModelToRequest(ctx context.Context, m *firewallPolicyResourceModel) *firewallPolicyScheduleRequest {
+	if m.Schedule.IsNull() || m.Schedule.IsUnknown() {
+		return nil
+	}
+	var sched firewallPolicyScheduleModel
+	m.Schedule.As(ctx, &sched, basetypes.ObjectAsOptions{})
+
+	req := &firewallPolicyScheduleRequest{
+		Mode:           sched.Mode.ValueString(),
+		Date:           sched.Date.ValueString(),
+		TimeRangeStart: sched.TimeRangeStart.ValueString(),
+		TimeRangeEnd:   sched.TimeRangeEnd.ValueString(),
+		DateRangeStart: sched.DateRangeStart.ValueString(),
+		DateRangeEnd:   sched.DateRangeEnd.ValueString(),
+	}
+	if sched.TimeAllDay.ValueBool() {
+		req.TimeAllDay = boolPtr(true)
+	}
+	if !sched.RepeatOnDays.IsNull() && !sched.RepeatOnDays.IsUnknown() {
+		var days []string
+		sched.RepeatOnDays.ElementsAs(ctx, &days, false)
+		req.RepeatOnDays = days
+	}
+	return req
+}
+
+func (r *firewallPolicyResource) apiToModel(full *firewallPolicyFull, m *firewallPolicyResourceModel, site string) {
+	policy := full.FirewallPolicy
 	m.ID = types.StringValue(policy.ID)
 	m.Site = types.StringValue(site)
 	m.Name = types.StringValue(policy.Name)
@@ -753,8 +797,8 @@ func (r *firewallPolicyResource) apiToModel(policy *unifi.FirewallPolicy, m *fir
 		m.Destination = types.ObjectNull(endpointAttrTypes)
 	}
 
-	if policy.Schedule != nil && !isDefaultSchedule(policy.Schedule) {
-		m.Schedule = scheduleAPIToModel(policy.Schedule)
+	if full.RawSchedule != nil && !isDefaultSchedule(full.RawSchedule) {
+		m.Schedule = scheduleAPIToModel(full.RawSchedule)
 	} else {
 		m.Schedule = types.ObjectNull(scheduleAttrTypes)
 	}
@@ -844,13 +888,19 @@ func populateTypedEndpointFields(attrs map[string]attr.Value, matchingTarget str
 	}
 }
 
-func scheduleAPIToModel(sched *unifi.FirewallPolicySchedule) types.Object {
+func scheduleAPIToModel(sched *firewallPolicyScheduleRequest) types.Object {
+	timeAllDay := false
+	if sched.TimeAllDay != nil {
+		timeAllDay = *sched.TimeAllDay
+	}
 	attrs := map[string]attr.Value{
 		"mode":             stringValueOrNull(sched.Mode),
 		"date":             stringValueOrNull(sched.Date),
-		"time_all_day":     boolValueOrNull(sched.TimeAllDay),
+		"time_all_day":     boolValueOrNull(timeAllDay),
 		"time_range_start": stringValueOrNull(sched.TimeRangeStart),
 		"time_range_end":   stringValueOrNull(sched.TimeRangeEnd),
+		"date_range_start": stringValueOrNull(sched.DateRangeStart),
+		"date_range_end":   stringValueOrNull(sched.DateRangeEnd),
 	}
 
 	if sched.RepeatOnDays != nil {
@@ -876,11 +926,14 @@ func stringValueOrNull(s string) types.String {
 // isDefaultSchedule returns true when the schedule is the API's default
 // (mode=ALWAYS with no other fields set). We treat this as "no schedule
 // configured" so that omitting the schedule block doesn't cause drift.
-func isDefaultSchedule(s *unifi.FirewallPolicySchedule) bool {
+func isDefaultSchedule(s *firewallPolicyScheduleRequest) bool {
+	timeAllDay := s.TimeAllDay != nil && *s.TimeAllDay
 	return s.Mode == "ALWAYS" &&
 		s.Date == "" &&
-		!s.TimeAllDay &&
+		!timeAllDay &&
 		s.TimeRangeStart == "" &&
 		s.TimeRangeEnd == "" &&
-		len(s.RepeatOnDays) == 0
+		len(s.RepeatOnDays) == 0 &&
+		s.DateRangeStart == "" &&
+		s.DateRangeEnd == ""
 }

--- a/internal/provider/firewall_policy_resource_test.go
+++ b/internal/provider/firewall_policy_resource_test.go
@@ -2124,8 +2124,8 @@ resource "terrifi_firewall_policy" "test" {
     time_range_start = "09:00"
     time_range_end   = "12:00"
     repeat_on_days   = ["mon", "tue", "wed", "thu", "fri", "sat", "sun"]
-    date_range_start = "2030-01-01"
-    date_range_end   = "2030-12-31"
+    date_start       = "2030-01-01"
+    date_end         = "2030-12-31"
   }
 `),
 				Check: resource.ComposeTestCheckFunc(
@@ -2133,8 +2133,8 @@ resource "terrifi_firewall_policy" "test" {
 					resource.TestCheckResourceAttr("terrifi_firewall_policy.test", "schedule.time_range_start", "09:00"),
 					resource.TestCheckResourceAttr("terrifi_firewall_policy.test", "schedule.time_range_end", "12:00"),
 					resource.TestCheckResourceAttr("terrifi_firewall_policy.test", "schedule.repeat_on_days.#", "7"),
-					resource.TestCheckResourceAttr("terrifi_firewall_policy.test", "schedule.date_range_start", "2030-01-01"),
-					resource.TestCheckResourceAttr("terrifi_firewall_policy.test", "schedule.date_range_end", "2030-12-31"),
+					resource.TestCheckResourceAttr("terrifi_firewall_policy.test", "schedule.date_start", "2030-01-01"),
+					resource.TestCheckResourceAttr("terrifi_firewall_policy.test", "schedule.date_end", "2030-12-31"),
 				),
 			},
 			// Subset of days with updated date range.
@@ -2145,8 +2145,8 @@ resource "terrifi_firewall_policy" "test" {
     time_range_start = "08:00"
     time_range_end   = "18:00"
     repeat_on_days   = ["mon", "wed", "fri"]
-    date_range_start = "2030-03-01"
-    date_range_end   = "2030-06-30"
+    date_start       = "2030-03-01"
+    date_end         = "2030-06-30"
   }
 `),
 				Check: resource.ComposeTestCheckFunc(
@@ -2154,8 +2154,8 @@ resource "terrifi_firewall_policy" "test" {
 					resource.TestCheckResourceAttr("terrifi_firewall_policy.test", "schedule.time_range_start", "08:00"),
 					resource.TestCheckResourceAttr("terrifi_firewall_policy.test", "schedule.time_range_end", "18:00"),
 					resource.TestCheckResourceAttr("terrifi_firewall_policy.test", "schedule.repeat_on_days.#", "3"),
-					resource.TestCheckResourceAttr("terrifi_firewall_policy.test", "schedule.date_range_start", "2030-03-01"),
-					resource.TestCheckResourceAttr("terrifi_firewall_policy.test", "schedule.date_range_end", "2030-06-30"),
+					resource.TestCheckResourceAttr("terrifi_firewall_policy.test", "schedule.date_start", "2030-03-01"),
+					resource.TestCheckResourceAttr("terrifi_firewall_policy.test", "schedule.date_end", "2030-06-30"),
 				),
 			},
 			{

--- a/internal/provider/firewall_policy_resource_test.go
+++ b/internal/provider/firewall_policy_resource_test.go
@@ -1940,6 +1940,84 @@ resource "terrifi_firewall_policy" "test" {
 	})
 }
 
+func TestAccFirewallPolicy_customSchedule(t *testing.T) {
+	zone1Name := fmt.Sprintf("tfacc-pol-csc-z1-%s", randomSuffix())
+	zone2Name := fmt.Sprintf("tfacc-pol-csc-z2-%s", randomSuffix())
+	policyName := fmt.Sprintf("tfacc-pol-custom-sched-%s", randomSuffix())
+
+	zonesConfig := testAccFirewallPolicyZonesConfig(zone1Name, zone2Name)
+	baseConfig := func(extra string) string {
+		return zonesConfig + fmt.Sprintf(`
+resource "terrifi_firewall_policy" "test" {
+  name   = %q
+  action = "BLOCK"
+
+  source {
+    zone_id = terrifi_firewall_zone.zone1.id
+  }
+
+  destination {
+    zone_id = terrifi_firewall_zone.zone2.id
+  }
+%s}
+`, policyName, extra)
+	}
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:                 func() { preCheck(t); requireHardware(t) },
+		ProtoV6ProviderFactories: testAccProtoV6ProviderFactories,
+		Steps: []resource.TestStep{
+			// Create directly with CUSTOM mode.
+			{
+				Config: baseConfig(`
+  schedule {
+    mode             = "CUSTOM"
+    time_range_start = "09:00"
+    time_range_end   = "12:00"
+    repeat_on_days   = ["mon", "wed", "fri"]
+  }
+`),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr("terrifi_firewall_policy.test", "schedule.mode", "CUSTOM"),
+					resource.TestCheckResourceAttr("terrifi_firewall_policy.test", "schedule.time_range_start", "09:00"),
+					resource.TestCheckResourceAttr("terrifi_firewall_policy.test", "schedule.time_range_end", "12:00"),
+					resource.TestCheckResourceAttr("terrifi_firewall_policy.test", "schedule.repeat_on_days.#", "3"),
+				),
+			},
+			// Update time range and days.
+			{
+				Config: baseConfig(`
+  schedule {
+    mode             = "CUSTOM"
+    time_range_start = "08:00"
+    time_range_end   = "18:00"
+    repeat_on_days   = ["mon", "tue", "wed", "thu", "fri", "sat", "sun"]
+  }
+`),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr("terrifi_firewall_policy.test", "schedule.mode", "CUSTOM"),
+					resource.TestCheckResourceAttr("terrifi_firewall_policy.test", "schedule.time_range_start", "08:00"),
+					resource.TestCheckResourceAttr("terrifi_firewall_policy.test", "schedule.time_range_end", "18:00"),
+					resource.TestCheckResourceAttr("terrifi_firewall_policy.test", "schedule.repeat_on_days.#", "7"),
+				),
+			},
+			// Import with CUSTOM schedule intact.
+			{
+				ResourceName:      "terrifi_firewall_policy.test",
+				ImportState:       true,
+				ImportStateVerify: true,
+			},
+			// Remove the schedule — verifies removal works after CUSTOM was set.
+			{
+				Config: baseConfig(""),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckNoResourceAttr("terrifi_firewall_policy.test", "schedule.mode"),
+				),
+			},
+		},
+	})
+}
+
 func TestAccFirewallPolicy_disabled(t *testing.T) {
 	zone1Name := fmt.Sprintf("tfacc-pol-dis-z1-%s", randomSuffix())
 	zone2Name := fmt.Sprintf("tfacc-pol-dis-z2-%s", randomSuffix())

--- a/internal/provider/firewall_policy_resource_test.go
+++ b/internal/provider/firewall_policy_resource_test.go
@@ -213,6 +213,75 @@ func TestFirewallPolicyModelToAPI(t *testing.T) {
 		assert.ElementsMatch(t, []string{"mon", "tue", "wed"}, policy.Schedule.RepeatOnDays)
 	})
 
+	t.Run("with CUSTOM schedule mode", func(t *testing.T) {
+		srcObj := types.ObjectValueMust(endpointAttrTypes, map[string]attr.Value{
+			"zone_id":              types.StringValue("zone-src"),
+			"ips":                  types.SetNull(types.StringType),
+			"mac_addresses":        types.SetNull(types.StringType),
+			"network_ids":          types.SetNull(types.StringType),
+			"device_ids":           types.SetNull(types.StringType),
+			"port_matching_type":   types.StringValue("ANY"),
+			"port":                 types.Int64Null(),
+			"port_group_id":        types.StringNull(),
+			"match_opposite_ports": types.BoolNull(),
+			"match_opposite_ips":   types.BoolNull(),
+		})
+		dstObj := types.ObjectValueMust(endpointAttrTypes, map[string]attr.Value{
+			"zone_id":              types.StringValue("zone-dst"),
+			"ips":                  types.SetNull(types.StringType),
+			"mac_addresses":        types.SetNull(types.StringType),
+			"network_ids":          types.SetNull(types.StringType),
+			"device_ids":           types.SetNull(types.StringType),
+			"port_matching_type":   types.StringValue("ANY"),
+			"port":                 types.Int64Null(),
+			"port_group_id":        types.StringNull(),
+			"match_opposite_ports": types.BoolNull(),
+			"match_opposite_ips":   types.BoolNull(),
+		})
+		schedObj := types.ObjectValueMust(scheduleAttrTypes, map[string]attr.Value{
+			"mode":             types.StringValue("CUSTOM"),
+			"date":             types.StringNull(),
+			"time_all_day":     types.BoolNull(),
+			"time_range_start": types.StringValue("09:00"),
+			"time_range_end":   types.StringValue("12:00"),
+			"repeat_on_days": types.SetValueMust(types.StringType, []attr.Value{
+				types.StringValue("mon"),
+				types.StringValue("tue"),
+				types.StringValue("wed"),
+				types.StringValue("thu"),
+				types.StringValue("fri"),
+				types.StringValue("sat"),
+				types.StringValue("sun"),
+			}),
+		})
+
+		model := &firewallPolicyResourceModel{
+			Name:                types.StringValue("Custom Schedule Block"),
+			Action:              types.StringValue("BLOCK"),
+			Enabled:             types.BoolValue(true),
+			IPVersion:           types.StringValue("BOTH"),
+			Protocol:            types.StringValue("all"),
+			ConnectionStateType: types.StringValue("ALL"),
+			ConnectionStates:    types.SetNull(types.StringType),
+			Description:         types.StringNull(),
+			MatchIPSec:          types.BoolNull(),
+			Logging:             types.BoolNull(),
+			CreateAllowRespond:  types.BoolNull(),
+			Index:               types.Int64Null(),
+			Source:              srcObj,
+			Destination:         dstObj,
+			Schedule:            schedObj,
+		}
+
+		policy := r.modelToAPI(ctx, model)
+
+		assert.NotNil(t, policy.Schedule)
+		assert.Equal(t, "CUSTOM", policy.Schedule.Mode)
+		assert.Equal(t, "09:00", policy.Schedule.TimeRangeStart)
+		assert.Equal(t, "12:00", policy.Schedule.TimeRangeEnd)
+		assert.ElementsMatch(t, []string{"mon", "tue", "wed", "thu", "fri", "sat", "sun"}, policy.Schedule.RepeatOnDays)
+	})
+
 	t.Run("disabled rule", func(t *testing.T) {
 		srcObj := types.ObjectValueMust(endpointAttrTypes, map[string]attr.Value{
 			"zone_id":              types.StringValue("zone-src"),
@@ -976,6 +1045,37 @@ func TestFirewallPolicyAPIToModel(t *testing.T) {
 		r.apiToModel(policy, &model, "default")
 
 		assert.False(t, model.Schedule.IsNull())
+	})
+
+	t.Run("CUSTOM schedule mode round-trip", func(t *testing.T) {
+		policy := &unifi.FirewallPolicy{
+			ID:     "pol-custom",
+			Name:   "Custom Schedule",
+			Action: "BLOCK",
+			Source: &unifi.FirewallPolicySource{
+				ZoneID: "zone-src",
+			},
+			Destination: &unifi.FirewallPolicyDestination{
+				ZoneID: "zone-dst",
+			},
+			Schedule: &unifi.FirewallPolicySchedule{
+				Mode:           "CUSTOM",
+				TimeRangeStart: "09:00",
+				TimeRangeEnd:   "12:00",
+				RepeatOnDays:   []string{"mon", "tue", "wed", "thu", "fri", "sat", "sun"},
+			},
+		}
+
+		var model firewallPolicyResourceModel
+		r.apiToModel(policy, &model, "default")
+
+		assert.False(t, model.Schedule.IsNull())
+		var sched firewallPolicyScheduleModel
+		model.Schedule.As(context.Background(), &sched, basetypes.ObjectAsOptions{})
+		assert.Equal(t, "CUSTOM", sched.Mode.ValueString())
+		assert.Equal(t, "09:00", sched.TimeRangeStart.ValueString())
+		assert.Equal(t, "12:00", sched.TimeRangeEnd.ValueString())
+		assert.Equal(t, 7, len(sched.RepeatOnDays.Elements()))
 	})
 
 	t.Run("MAC matching target populates mac_addresses", func(t *testing.T) {
@@ -1816,6 +1916,24 @@ resource "terrifi_firewall_policy" "test" {
 				Config: baseConfig(""),
 				Check: resource.ComposeTestCheckFunc(
 					resource.TestCheckNoResourceAttr("terrifi_firewall_policy.test", "schedule.mode"),
+				),
+			},
+			// CUSTOM mode — returned by the API for manually-configured schedules
+			// in the UniFi UI; was rejected by the schema validator before this fix.
+			{
+				Config: baseConfig(`
+  schedule {
+    mode             = "CUSTOM"
+    time_range_start = "09:00"
+    time_range_end   = "12:00"
+    repeat_on_days   = ["mon", "tue", "wed", "thu", "fri", "sat", "sun"]
+  }
+`),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr("terrifi_firewall_policy.test", "schedule.mode", "CUSTOM"),
+					resource.TestCheckResourceAttr("terrifi_firewall_policy.test", "schedule.time_range_start", "09:00"),
+					resource.TestCheckResourceAttr("terrifi_firewall_policy.test", "schedule.time_range_end", "12:00"),
+					resource.TestCheckResourceAttr("terrifi_firewall_policy.test", "schedule.repeat_on_days.#", "7"),
 				),
 			},
 		},

--- a/internal/provider/firewall_policy_resource_test.go
+++ b/internal/provider/firewall_policy_resource_test.go
@@ -184,8 +184,8 @@ func TestFirewallPolicyModelToAPI(t *testing.T) {
 				types.StringValue("tue"),
 				types.StringValue("wed"),
 			}),
-			"date_range_start": types.StringNull(),
-			"date_range_end":   types.StringNull(),
+			"date_start": types.StringNull(),
+			"date_end":   types.StringNull(),
 		})
 
 		model := &firewallPolicyResourceModel{
@@ -255,8 +255,8 @@ func TestFirewallPolicyModelToAPI(t *testing.T) {
 				types.StringValue("sat"),
 				types.StringValue("sun"),
 			}),
-			"date_range_start": types.StringValue("2030-01-01"),
-			"date_range_end":   types.StringValue("2030-12-31"),
+			"date_start": types.StringValue("2030-01-01"),
+			"date_end":   types.StringValue("2030-12-31"),
 		})
 
 		model := &firewallPolicyResourceModel{
@@ -1125,8 +1125,8 @@ func TestFirewallPolicyAPIToModel(t *testing.T) {
 				TimeRangeStart: "09:00",
 				TimeRangeEnd:   "12:00",
 				RepeatOnDays:   []string{"mon", "tue", "wed", "thu", "fri", "sat", "sun"},
-				DateRangeStart: "2030-01-01",
-				DateRangeEnd:   "2030-12-31",
+				DateStart: "2030-01-01",
+				DateEnd:   "2030-12-31",
 			},
 		}, &model, "default")
 
@@ -1137,8 +1137,8 @@ func TestFirewallPolicyAPIToModel(t *testing.T) {
 		assert.Equal(t, "09:00", sched.TimeRangeStart.ValueString())
 		assert.Equal(t, "12:00", sched.TimeRangeEnd.ValueString())
 		assert.Equal(t, 7, len(sched.RepeatOnDays.Elements()))
-		assert.Equal(t, "2030-01-01", sched.DateRangeStart.ValueString())
-		assert.Equal(t, "2030-12-31", sched.DateRangeEnd.ValueString())
+		assert.Equal(t, "2030-01-01", sched.DateStart.ValueString())
+		assert.Equal(t, "2030-12-31", sched.DateEnd.ValueString())
 	})
 
 	t.Run("MAC matching target populates mac_addresses", func(t *testing.T) {
@@ -1398,8 +1398,8 @@ func TestFirewallPolicyApplyPlanToState(t *testing.T) {
 			"time_range_start": types.StringValue("09:00"),
 			"time_range_end":   types.StringValue("12:00"),
 			"repeat_on_days":   types.SetNull(types.StringType),
-			"date_range_start": types.StringNull(),
-			"date_range_end":   types.StringNull(),
+			"date_start": types.StringNull(),
+			"date_end":   types.StringNull(),
 		})
 		state := &firewallPolicyResourceModel{
 			Name:     types.StringValue("Scheduled Policy"),

--- a/internal/provider/firewall_policy_resource_test.go
+++ b/internal/provider/firewall_policy_resource_test.go
@@ -9,6 +9,7 @@ import (
 	"testing"
 
 	"github.com/hashicorp/terraform-plugin-framework/attr"
+	"github.com/hashicorp/terraform-plugin-framework/schema/validator"
 	"github.com/hashicorp/terraform-plugin-framework/types"
 	"github.com/hashicorp/terraform-plugin-framework/types/basetypes"
 	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
@@ -1444,6 +1445,68 @@ func TestFirewallPolicyApplyPlanToState(t *testing.T) {
 		assert.True(t, state.Logging.IsNull(), "logging should be cleared")
 		assert.True(t, state.MatchIPSec.IsNull(), "match_ipsec should be cleared")
 		assert.True(t, state.CreateAllowRespond.IsNull(), "create_allow_respond should be cleared")
+	})
+}
+
+func TestScheduleCustomRequiresDatesValidator(t *testing.T) {
+	v := scheduleCustomRequiresDatesValidator{}
+	ctx := context.Background()
+
+	makeScheduleObj := func(mode, dateStart, dateEnd string) types.Object {
+		attrs := map[string]attr.Value{
+			"mode":             types.StringValue(mode),
+			"date":             types.StringNull(),
+			"time_all_day":     types.BoolNull(),
+			"time_range_start": types.StringValue("09:00"),
+			"time_range_end":   types.StringValue("17:00"),
+			"repeat_on_days":   types.SetNull(types.StringType),
+			"date_start":       types.StringNull(),
+			"date_end":         types.StringNull(),
+		}
+		if dateStart != "" {
+			attrs["date_start"] = types.StringValue(dateStart)
+		}
+		if dateEnd != "" {
+			attrs["date_end"] = types.StringValue(dateEnd)
+		}
+		return types.ObjectValueMust(scheduleAttrTypes, attrs)
+	}
+
+	t.Run("CUSTOM with both dates passes", func(t *testing.T) {
+		req := validator.ObjectRequest{ConfigValue: makeScheduleObj("CUSTOM", "2030-01-01", "2030-12-31")}
+		var resp validator.ObjectResponse
+		v.ValidateObject(ctx, req, &resp)
+		assert.False(t, resp.Diagnostics.HasError())
+	})
+
+	t.Run("CUSTOM missing date_start fails", func(t *testing.T) {
+		req := validator.ObjectRequest{ConfigValue: makeScheduleObj("CUSTOM", "", "2030-12-31")}
+		var resp validator.ObjectResponse
+		v.ValidateObject(ctx, req, &resp)
+		assert.True(t, resp.Diagnostics.HasError())
+		assert.Contains(t, resp.Diagnostics.Errors()[0].Summary(), "Missing Required Attribute")
+	})
+
+	t.Run("CUSTOM missing date_end fails", func(t *testing.T) {
+		req := validator.ObjectRequest{ConfigValue: makeScheduleObj("CUSTOM", "2030-01-01", "")}
+		var resp validator.ObjectResponse
+		v.ValidateObject(ctx, req, &resp)
+		assert.True(t, resp.Diagnostics.HasError())
+		assert.Contains(t, resp.Diagnostics.Errors()[0].Summary(), "Missing Required Attribute")
+	})
+
+	t.Run("EVERY_WEEK without dates passes", func(t *testing.T) {
+		req := validator.ObjectRequest{ConfigValue: makeScheduleObj("EVERY_WEEK", "", "")}
+		var resp validator.ObjectResponse
+		v.ValidateObject(ctx, req, &resp)
+		assert.False(t, resp.Diagnostics.HasError())
+	})
+
+	t.Run("null schedule object is skipped", func(t *testing.T) {
+		req := validator.ObjectRequest{ConfigValue: types.ObjectNull(scheduleAttrTypes)}
+		var resp validator.ObjectResponse
+		v.ValidateObject(ctx, req, &resp)
+		assert.False(t, resp.Diagnostics.HasError())
 	})
 }
 

--- a/internal/provider/firewall_policy_resource_test.go
+++ b/internal/provider/firewall_policy_resource_test.go
@@ -2055,10 +2055,6 @@ resource "terrifi_firewall_policy" "test" {
 	})
 }
 
-// TestAccFirewallPolicy_customSchedule tests CUSTOM schedule mode with a date.
-// CUSTOM without a date returns 400 "Missing date range" from the API. This
-// test probes whether providing date is sufficient to create a CUSTOM schedule.
-// If the API still rejects it, additional date-range fields may be needed.
 func TestAccFirewallPolicy_customSchedule(t *testing.T) {
 	zone1Name := fmt.Sprintf("tfacc-pol-csc-z1-%s", randomSuffix())
 	zone2Name := fmt.Sprintf("tfacc-pol-csc-z2-%s", randomSuffix())
@@ -2085,10 +2081,6 @@ resource "terrifi_firewall_policy" "test" {
 	resource.Test(t, resource.TestCase{
 		PreCheck:                 func() { preCheck(t); requireHardware(t) },
 		ProtoV6ProviderFactories: testAccProtoV6ProviderFactories,
-		// CUSTOM mode requires all 7 days when no date range is provided. With a
-		// subset of days the API returns 400 "Missing date range", indicating that
-		// partial-week CUSTOM schedules also need a start/end date (not yet
-		// supported by the schema).
 		Steps: []resource.TestStep{
 			{
 				Config: baseConfig(`
@@ -2106,20 +2098,21 @@ resource "terrifi_firewall_policy" "test" {
 					resource.TestCheckResourceAttr("terrifi_firewall_policy.test", "schedule.repeat_on_days.#", "7"),
 				),
 			},
+			// Subset of days.
 			{
 				Config: baseConfig(`
   schedule {
     mode             = "CUSTOM"
     time_range_start = "08:00"
     time_range_end   = "18:00"
-    repeat_on_days   = ["mon", "tue", "wed", "thu", "fri", "sat", "sun"]
+    repeat_on_days   = ["mon", "wed", "fri"]
   }
 `),
 				Check: resource.ComposeTestCheckFunc(
 					resource.TestCheckResourceAttr("terrifi_firewall_policy.test", "schedule.mode", "CUSTOM"),
 					resource.TestCheckResourceAttr("terrifi_firewall_policy.test", "schedule.time_range_start", "08:00"),
 					resource.TestCheckResourceAttr("terrifi_firewall_policy.test", "schedule.time_range_end", "18:00"),
-					resource.TestCheckResourceAttr("terrifi_firewall_policy.test", "schedule.repeat_on_days.#", "7"),
+					resource.TestCheckResourceAttr("terrifi_firewall_policy.test", "schedule.repeat_on_days.#", "3"),
 				),
 			},
 			{

--- a/internal/provider/firewall_policy_resource_test.go
+++ b/internal/provider/firewall_policy_resource_test.go
@@ -2055,6 +2055,86 @@ resource "terrifi_firewall_policy" "test" {
 	})
 }
 
+// TestAccFirewallPolicy_customSchedule tests CUSTOM schedule mode with a date.
+// CUSTOM without a date returns 400 "Missing date range" from the API. This
+// test probes whether providing date is sufficient to create a CUSTOM schedule.
+// If the API still rejects it, additional date-range fields may be needed.
+func TestAccFirewallPolicy_customSchedule(t *testing.T) {
+	zone1Name := fmt.Sprintf("tfacc-pol-csc-z1-%s", randomSuffix())
+	zone2Name := fmt.Sprintf("tfacc-pol-csc-z2-%s", randomSuffix())
+	policyName := fmt.Sprintf("tfacc-pol-csc-%s", randomSuffix())
+
+	zonesConfig := testAccFirewallPolicyZonesConfig(zone1Name, zone2Name)
+	baseConfig := func(extra string) string {
+		return zonesConfig + fmt.Sprintf(`
+resource "terrifi_firewall_policy" "test" {
+  name   = %q
+  action = "BLOCK"
+
+  source {
+    zone_id = terrifi_firewall_zone.zone1.id
+  }
+
+  destination {
+    zone_id = terrifi_firewall_zone.zone2.id
+  }
+%s}
+`, policyName, extra)
+	}
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:                 func() { preCheck(t); requireHardware(t) },
+		ProtoV6ProviderFactories: testAccProtoV6ProviderFactories,
+		Steps: []resource.TestStep{
+			{
+				Config: baseConfig(`
+  schedule {
+    mode             = "CUSTOM"
+    date             = "2030-01-01"
+    time_range_start = "09:00"
+    time_range_end   = "12:00"
+    repeat_on_days   = ["mon", "wed", "fri"]
+  }
+`),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr("terrifi_firewall_policy.test", "schedule.mode", "CUSTOM"),
+					resource.TestCheckResourceAttr("terrifi_firewall_policy.test", "schedule.date", "2030-01-01"),
+					resource.TestCheckResourceAttr("terrifi_firewall_policy.test", "schedule.time_range_start", "09:00"),
+					resource.TestCheckResourceAttr("terrifi_firewall_policy.test", "schedule.time_range_end", "12:00"),
+					resource.TestCheckResourceAttr("terrifi_firewall_policy.test", "schedule.repeat_on_days.#", "3"),
+				),
+			},
+			{
+				Config: baseConfig(`
+  schedule {
+    mode             = "CUSTOM"
+    date             = "2030-06-15"
+    time_range_start = "08:00"
+    time_range_end   = "18:00"
+    repeat_on_days   = ["mon", "tue", "wed", "thu", "fri", "sat", "sun"]
+  }
+`),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr("terrifi_firewall_policy.test", "schedule.mode", "CUSTOM"),
+					resource.TestCheckResourceAttr("terrifi_firewall_policy.test", "schedule.date", "2030-06-15"),
+					resource.TestCheckResourceAttr("terrifi_firewall_policy.test", "schedule.repeat_on_days.#", "7"),
+				),
+			},
+			{
+				ResourceName:      "terrifi_firewall_policy.test",
+				ImportState:       true,
+				ImportStateVerify: true,
+			},
+			{
+				Config: baseConfig(""),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckNoResourceAttr("terrifi_firewall_policy.test", "schedule.mode"),
+				),
+			},
+		},
+	})
+}
+
 func TestAccFirewallPolicy_disabled(t *testing.T) {
 	zone1Name := fmt.Sprintf("tfacc-pol-dis-z1-%s", randomSuffix())
 	zone2Name := fmt.Sprintf("tfacc-pol-dis-z2-%s", randomSuffix())

--- a/internal/provider/firewall_policy_resource_test.go
+++ b/internal/provider/firewall_policy_resource_test.go
@@ -2085,30 +2085,31 @@ resource "terrifi_firewall_policy" "test" {
 	resource.Test(t, resource.TestCase{
 		PreCheck:                 func() { preCheck(t); requireHardware(t) },
 		ProtoV6ProviderFactories: testAccProtoV6ProviderFactories,
+		// CUSTOM mode requires all 7 days when no date range is provided. With a
+		// subset of days the API returns 400 "Missing date range", indicating that
+		// partial-week CUSTOM schedules also need a start/end date (not yet
+		// supported by the schema).
 		Steps: []resource.TestStep{
 			{
 				Config: baseConfig(`
   schedule {
     mode             = "CUSTOM"
-    date             = "2030-01-01"
     time_range_start = "09:00"
     time_range_end   = "12:00"
-    repeat_on_days   = ["mon", "wed", "fri"]
+    repeat_on_days   = ["mon", "tue", "wed", "thu", "fri", "sat", "sun"]
   }
 `),
 				Check: resource.ComposeTestCheckFunc(
 					resource.TestCheckResourceAttr("terrifi_firewall_policy.test", "schedule.mode", "CUSTOM"),
-					resource.TestCheckResourceAttr("terrifi_firewall_policy.test", "schedule.date", "2030-01-01"),
 					resource.TestCheckResourceAttr("terrifi_firewall_policy.test", "schedule.time_range_start", "09:00"),
 					resource.TestCheckResourceAttr("terrifi_firewall_policy.test", "schedule.time_range_end", "12:00"),
-					resource.TestCheckResourceAttr("terrifi_firewall_policy.test", "schedule.repeat_on_days.#", "3"),
+					resource.TestCheckResourceAttr("terrifi_firewall_policy.test", "schedule.repeat_on_days.#", "7"),
 				),
 			},
 			{
 				Config: baseConfig(`
   schedule {
     mode             = "CUSTOM"
-    date             = "2030-06-15"
     time_range_start = "08:00"
     time_range_end   = "18:00"
     repeat_on_days   = ["mon", "tue", "wed", "thu", "fri", "sat", "sun"]
@@ -2116,7 +2117,8 @@ resource "terrifi_firewall_policy" "test" {
 `),
 				Check: resource.ComposeTestCheckFunc(
 					resource.TestCheckResourceAttr("terrifi_firewall_policy.test", "schedule.mode", "CUSTOM"),
-					resource.TestCheckResourceAttr("terrifi_firewall_policy.test", "schedule.date", "2030-06-15"),
+					resource.TestCheckResourceAttr("terrifi_firewall_policy.test", "schedule.time_range_start", "08:00"),
+					resource.TestCheckResourceAttr("terrifi_firewall_policy.test", "schedule.time_range_end", "18:00"),
 					resource.TestCheckResourceAttr("terrifi_firewall_policy.test", "schedule.repeat_on_days.#", "7"),
 				),
 			},

--- a/internal/provider/firewall_policy_resource_test.go
+++ b/internal/provider/firewall_policy_resource_test.go
@@ -1047,6 +1047,37 @@ func TestFirewallPolicyAPIToModel(t *testing.T) {
 		assert.False(t, model.Schedule.IsNull())
 	})
 
+	t.Run("ONE_TIME_ONLY schedule mode round-trip", func(t *testing.T) {
+		policy := &unifi.FirewallPolicy{
+			ID:     "pol-oto",
+			Name:   "One Time Only",
+			Action: "BLOCK",
+			Source: &unifi.FirewallPolicySource{
+				ZoneID: "zone-src",
+			},
+			Destination: &unifi.FirewallPolicyDestination{
+				ZoneID: "zone-dst",
+			},
+			Schedule: &unifi.FirewallPolicySchedule{
+				Mode:           "ONE_TIME_ONLY",
+				Date:           "2030-01-01",
+				TimeRangeStart: "09:00",
+				TimeRangeEnd:   "12:00",
+			},
+		}
+
+		var model firewallPolicyResourceModel
+		r.apiToModel(policy, &model, "default")
+
+		assert.False(t, model.Schedule.IsNull())
+		var sched firewallPolicyScheduleModel
+		model.Schedule.As(context.Background(), &sched, basetypes.ObjectAsOptions{})
+		assert.Equal(t, "ONE_TIME_ONLY", sched.Mode.ValueString())
+		assert.Equal(t, "2030-01-01", sched.Date.ValueString())
+		assert.Equal(t, "09:00", sched.TimeRangeStart.ValueString())
+		assert.Equal(t, "12:00", sched.TimeRangeEnd.ValueString())
+	})
+
 	t.Run("CUSTOM schedule mode round-trip", func(t *testing.T) {
 		policy := &unifi.FirewallPolicy{
 			ID:     "pol-custom",
@@ -1918,32 +1949,38 @@ resource "terrifi_firewall_policy" "test" {
 					resource.TestCheckNoResourceAttr("terrifi_firewall_policy.test", "schedule.mode"),
 				),
 			},
-			// CUSTOM mode — returned by the API for manually-configured schedules
-			// in the UniFi UI; was rejected by the schema validator before this fix.
+			// ONE_TIME_ONLY mode — verified working scenario from issue report.
+			// CUSTOM mode is returned by the API for some UI-created schedules but
+			// cannot be set via the API (returns 400 "Missing date range"); use
+			// ONE_TIME_ONLY instead when a date-bounded schedule is needed.
 			{
 				Config: baseConfig(`
   schedule {
-    mode             = "CUSTOM"
+    mode             = "ONE_TIME_ONLY"
+    date             = "2030-01-01"
     time_range_start = "09:00"
     time_range_end   = "12:00"
-    repeat_on_days   = ["mon", "tue", "wed", "thu", "fri", "sat", "sun"]
   }
 `),
 				Check: resource.ComposeTestCheckFunc(
-					resource.TestCheckResourceAttr("terrifi_firewall_policy.test", "schedule.mode", "CUSTOM"),
+					resource.TestCheckResourceAttr("terrifi_firewall_policy.test", "schedule.mode", "ONE_TIME_ONLY"),
+					resource.TestCheckResourceAttr("terrifi_firewall_policy.test", "schedule.date", "2030-01-01"),
 					resource.TestCheckResourceAttr("terrifi_firewall_policy.test", "schedule.time_range_start", "09:00"),
 					resource.TestCheckResourceAttr("terrifi_firewall_policy.test", "schedule.time_range_end", "12:00"),
-					resource.TestCheckResourceAttr("terrifi_firewall_policy.test", "schedule.repeat_on_days.#", "7"),
 				),
 			},
 		},
 	})
 }
 
-func TestAccFirewallPolicy_customSchedule(t *testing.T) {
-	zone1Name := fmt.Sprintf("tfacc-pol-csc-z1-%s", randomSuffix())
-	zone2Name := fmt.Sprintf("tfacc-pol-csc-z2-%s", randomSuffix())
-	policyName := fmt.Sprintf("tfacc-pol-custom-sched-%s", randomSuffix())
+// TestAccFirewallPolicy_oneTimeOnly covers the ONE_TIME_ONLY schedule mode full
+// lifecycle: create, update, import, and removal. ONE_TIME_ONLY is the correct
+// mode to use for date-bounded schedules; CUSTOM is returned by the API for
+// certain UI-created schedules but cannot be set via the API directly.
+func TestAccFirewallPolicy_oneTimeOnly(t *testing.T) {
+	zone1Name := fmt.Sprintf("tfacc-pol-oto-z1-%s", randomSuffix())
+	zone2Name := fmt.Sprintf("tfacc-pol-oto-z2-%s", randomSuffix())
+	policyName := fmt.Sprintf("tfacc-pol-oto-%s", randomSuffix())
 
 	zonesConfig := testAccFirewallPolicyZonesConfig(zone1Name, zone2Name)
 	baseConfig := func(extra string) string {
@@ -1967,47 +2004,47 @@ resource "terrifi_firewall_policy" "test" {
 		PreCheck:                 func() { preCheck(t); requireHardware(t) },
 		ProtoV6ProviderFactories: testAccProtoV6ProviderFactories,
 		Steps: []resource.TestStep{
-			// Create directly with CUSTOM mode.
+			// Create with ONE_TIME_ONLY mode, date, and time range.
 			{
 				Config: baseConfig(`
   schedule {
-    mode             = "CUSTOM"
+    mode             = "ONE_TIME_ONLY"
+    date             = "2030-01-01"
     time_range_start = "09:00"
     time_range_end   = "12:00"
-    repeat_on_days   = ["mon", "wed", "fri"]
   }
 `),
 				Check: resource.ComposeTestCheckFunc(
-					resource.TestCheckResourceAttr("terrifi_firewall_policy.test", "schedule.mode", "CUSTOM"),
+					resource.TestCheckResourceAttr("terrifi_firewall_policy.test", "schedule.mode", "ONE_TIME_ONLY"),
+					resource.TestCheckResourceAttr("terrifi_firewall_policy.test", "schedule.date", "2030-01-01"),
 					resource.TestCheckResourceAttr("terrifi_firewall_policy.test", "schedule.time_range_start", "09:00"),
 					resource.TestCheckResourceAttr("terrifi_firewall_policy.test", "schedule.time_range_end", "12:00"),
-					resource.TestCheckResourceAttr("terrifi_firewall_policy.test", "schedule.repeat_on_days.#", "3"),
 				),
 			},
-			// Update time range and days.
+			// Update date and time range.
 			{
 				Config: baseConfig(`
   schedule {
-    mode             = "CUSTOM"
+    mode             = "ONE_TIME_ONLY"
+    date             = "2030-06-15"
     time_range_start = "08:00"
     time_range_end   = "18:00"
-    repeat_on_days   = ["mon", "tue", "wed", "thu", "fri", "sat", "sun"]
   }
 `),
 				Check: resource.ComposeTestCheckFunc(
-					resource.TestCheckResourceAttr("terrifi_firewall_policy.test", "schedule.mode", "CUSTOM"),
+					resource.TestCheckResourceAttr("terrifi_firewall_policy.test", "schedule.mode", "ONE_TIME_ONLY"),
+					resource.TestCheckResourceAttr("terrifi_firewall_policy.test", "schedule.date", "2030-06-15"),
 					resource.TestCheckResourceAttr("terrifi_firewall_policy.test", "schedule.time_range_start", "08:00"),
 					resource.TestCheckResourceAttr("terrifi_firewall_policy.test", "schedule.time_range_end", "18:00"),
-					resource.TestCheckResourceAttr("terrifi_firewall_policy.test", "schedule.repeat_on_days.#", "7"),
 				),
 			},
-			// Import with CUSTOM schedule intact.
+			// Import with ONE_TIME_ONLY schedule intact.
 			{
 				ResourceName:      "terrifi_firewall_policy.test",
 				ImportState:       true,
 				ImportStateVerify: true,
 			},
-			// Remove the schedule — verifies removal works after CUSTOM was set.
+			// Remove the schedule.
 			{
 				Config: baseConfig(""),
 				Check: resource.ComposeTestCheckFunc(

--- a/internal/provider/firewall_policy_resource_test.go
+++ b/internal/provider/firewall_policy_resource_test.go
@@ -1226,6 +1226,60 @@ func TestFirewallPolicyApplyPlanToState(t *testing.T) {
 		assert.Equal(t, "IPV4", state.IPVersion.ValueString())
 		assert.Equal(t, "tcp", state.Protocol.ValueString())
 	})
+
+	t.Run("null schedule in plan clears state schedule", func(t *testing.T) {
+		schedObj := types.ObjectValueMust(scheduleAttrTypes, map[string]attr.Value{
+			"mode":             types.StringValue("ALWAYS"),
+			"date":             types.StringValue("2025-07-02"),
+			"time_all_day":     types.BoolNull(),
+			"time_range_start": types.StringValue("09:00"),
+			"time_range_end":   types.StringValue("12:00"),
+			"repeat_on_days":   types.SetNull(types.StringType),
+		})
+		state := &firewallPolicyResourceModel{
+			Name:     types.StringValue("Scheduled Policy"),
+			Action:   types.StringValue("BLOCK"),
+			Schedule: schedObj,
+		}
+
+		plan := &firewallPolicyResourceModel{
+			Name:     types.StringValue("Scheduled Policy"),
+			Action:   types.StringValue("BLOCK"),
+			Schedule: types.ObjectNull(scheduleAttrTypes),
+		}
+
+		r.applyPlanToState(plan, state)
+
+		assert.True(t, state.Schedule.IsNull(), "schedule should be cleared when removed from plan")
+	})
+
+	t.Run("null optional fields in plan propagate to state", func(t *testing.T) {
+		state := &firewallPolicyResourceModel{
+			Name:               types.StringValue("My Policy"),
+			Action:             types.StringValue("ALLOW"),
+			Description:        types.StringValue("old description"),
+			Logging:            types.BoolValue(true),
+			MatchIPSec:         types.BoolValue(true),
+			CreateAllowRespond: types.BoolValue(true),
+		}
+
+		plan := &firewallPolicyResourceModel{
+			Name:               types.StringValue("My Policy"),
+			Action:             types.StringValue("ALLOW"),
+			Description:        types.StringNull(),
+			Logging:            types.BoolNull(),
+			MatchIPSec:         types.BoolNull(),
+			CreateAllowRespond: types.BoolNull(),
+			Schedule:           types.ObjectNull(scheduleAttrTypes),
+		}
+
+		r.applyPlanToState(plan, state)
+
+		assert.True(t, state.Description.IsNull(), "description should be cleared")
+		assert.True(t, state.Logging.IsNull(), "logging should be cleared")
+		assert.True(t, state.MatchIPSec.IsNull(), "match_ipsec should be cleared")
+		assert.True(t, state.CreateAllowRespond.IsNull(), "create_allow_respond should be cleared")
+	})
 }
 
 func TestBuildEndpointRequest(t *testing.T) {
@@ -1694,12 +1748,9 @@ func TestAccFirewallPolicy_schedule(t *testing.T) {
 	zone2Name := fmt.Sprintf("tfacc-pol-sc-z2-%s", randomSuffix())
 	policyName := fmt.Sprintf("tfacc-pol-sched-%s", randomSuffix())
 
-	resource.Test(t, resource.TestCase{
-		PreCheck:                 func() { preCheck(t); requireHardware(t) },
-		ProtoV6ProviderFactories: testAccProtoV6ProviderFactories,
-		Steps: []resource.TestStep{
-			{
-				Config: testAccFirewallPolicyZonesConfig(zone1Name, zone2Name) + fmt.Sprintf(`
+	zonesConfig := testAccFirewallPolicyZonesConfig(zone1Name, zone2Name)
+	baseConfig := func(extra string) string {
+		return zonesConfig + fmt.Sprintf(`
 resource "terrifi_firewall_policy" "test" {
   name   = %q
   action = "BLOCK"
@@ -1711,20 +1762,60 @@ resource "terrifi_firewall_policy" "test" {
   destination {
     zone_id = terrifi_firewall_zone.zone2.id
   }
+%s}
+`, policyName, extra)
+	}
 
+	resource.Test(t, resource.TestCase{
+		PreCheck:                 func() { preCheck(t); requireHardware(t) },
+		ProtoV6ProviderFactories: testAccProtoV6ProviderFactories,
+		Steps: []resource.TestStep{
+			{
+				Config: baseConfig(`
   schedule {
     mode             = "EVERY_WEEK"
     time_range_start = "08:00"
     time_range_end   = "17:00"
     repeat_on_days   = ["mon", "tue", "wed", "thu", "fri"]
   }
-}
-`, policyName),
+`),
 				Check: resource.ComposeTestCheckFunc(
 					resource.TestCheckResourceAttr("terrifi_firewall_policy.test", "schedule.mode", "EVERY_WEEK"),
 					resource.TestCheckResourceAttr("terrifi_firewall_policy.test", "schedule.time_range_start", "08:00"),
 					resource.TestCheckResourceAttr("terrifi_firewall_policy.test", "schedule.time_range_end", "17:00"),
 					resource.TestCheckResourceAttr("terrifi_firewall_policy.test", "schedule.repeat_on_days.#", "5"),
+				),
+			},
+			// Remove the schedule block — verifies the "was absent, but now present" bug is fixed.
+			{
+				Config: baseConfig(""),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckNoResourceAttr("terrifi_firewall_policy.test", "schedule.mode"),
+				),
+			},
+			// Re-add schedule with mode=ALWAYS plus extra fields (matches the exact
+			// scenario reported in issue #130 where isDefaultSchedule was not triggered).
+			{
+				Config: baseConfig(`
+  schedule {
+    mode             = "ALWAYS"
+    date             = "2025-07-02"
+    time_range_start = "09:00"
+    time_range_end   = "12:00"
+  }
+`),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr("terrifi_firewall_policy.test", "schedule.mode", "ALWAYS"),
+					resource.TestCheckResourceAttr("terrifi_firewall_policy.test", "schedule.date", "2025-07-02"),
+					resource.TestCheckResourceAttr("terrifi_firewall_policy.test", "schedule.time_range_start", "09:00"),
+					resource.TestCheckResourceAttr("terrifi_firewall_policy.test", "schedule.time_range_end", "12:00"),
+				),
+			},
+			// Remove ALWAYS+extra-fields schedule — the other variant of the bug.
+			{
+				Config: baseConfig(""),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckNoResourceAttr("terrifi_firewall_policy.test", "schedule.mode"),
 				),
 			},
 		},

--- a/internal/provider/firewall_policy_resource_test.go
+++ b/internal/provider/firewall_policy_resource_test.go
@@ -184,6 +184,8 @@ func TestFirewallPolicyModelToAPI(t *testing.T) {
 				types.StringValue("tue"),
 				types.StringValue("wed"),
 			}),
+			"date_range_start": types.StringNull(),
+			"date_range_end":   types.StringNull(),
 		})
 
 		model := &firewallPolicyResourceModel{
@@ -253,6 +255,8 @@ func TestFirewallPolicyModelToAPI(t *testing.T) {
 				types.StringValue("sat"),
 				types.StringValue("sun"),
 			}),
+			"date_range_start": types.StringValue("2030-01-01"),
+			"date_range_end":   types.StringValue("2030-12-31"),
 		})
 
 		model := &firewallPolicyResourceModel{
@@ -772,7 +776,7 @@ func TestFirewallPolicyAPIToModel(t *testing.T) {
 		}
 
 		var model firewallPolicyResourceModel
-		r.apiToModel(policy, &model, "default")
+		r.apiToModel(&firewallPolicyFull{FirewallPolicy: policy}, &model, "default")
 
 		assert.Equal(t, "pol-001", model.ID.ValueString())
 		assert.Equal(t, "default", model.Site.ValueString())
@@ -812,7 +816,7 @@ func TestFirewallPolicyAPIToModel(t *testing.T) {
 		}
 
 		var model firewallPolicyResourceModel
-		r.apiToModel(policy, &model, "mysite")
+		r.apiToModel(&firewallPolicyFull{FirewallPolicy: policy}, &model, "mysite")
 
 		assert.Equal(t, "pol-002", model.ID.ValueString())
 		assert.Equal(t, "mysite", model.Site.ValueString())
@@ -851,7 +855,7 @@ func TestFirewallPolicyAPIToModel(t *testing.T) {
 		}
 
 		var model firewallPolicyResourceModel
-		r.apiToModel(policy, &model, "default")
+		r.apiToModel(&firewallPolicyFull{FirewallPolicy: policy}, &model, "default")
 
 		assert.False(t, model.Enabled.ValueBool())
 		assert.True(t, model.Logging.IsNull())
@@ -873,7 +877,7 @@ func TestFirewallPolicyAPIToModel(t *testing.T) {
 		}
 
 		var model firewallPolicyResourceModel
-		r.apiToModel(policy, &model, "default")
+		r.apiToModel(&firewallPolicyFull{FirewallPolicy: policy}, &model, "default")
 
 		assert.True(t, model.Index.IsNull())
 	})
@@ -893,7 +897,7 @@ func TestFirewallPolicyAPIToModel(t *testing.T) {
 		}
 
 		var model firewallPolicyResourceModel
-		r.apiToModel(policy, &model, "default")
+		r.apiToModel(&firewallPolicyFull{FirewallPolicy: policy}, &model, "default")
 
 		assert.True(t, model.Description.IsNull())
 	})
@@ -912,7 +916,7 @@ func TestFirewallPolicyAPIToModel(t *testing.T) {
 		}
 
 		var model firewallPolicyResourceModel
-		r.apiToModel(policy, &model, "default")
+		r.apiToModel(&firewallPolicyFull{FirewallPolicy: policy}, &model, "default")
 
 		assert.Equal(t, "BOTH", model.IPVersion.ValueString())
 		assert.Equal(t, "all", model.Protocol.ValueString())
@@ -940,7 +944,7 @@ func TestFirewallPolicyAPIToModel(t *testing.T) {
 		}
 
 		var model firewallPolicyResourceModel
-		r.apiToModel(policy, &model, "default")
+		r.apiToModel(&firewallPolicyFull{FirewallPolicy: policy}, &model, "default")
 
 		assert.Equal(t, "ALL", model.ConnectionStateType.ValueString())
 		assert.True(t, model.ConnectionStates.IsNull())
@@ -965,7 +969,7 @@ func TestFirewallPolicyAPIToModel(t *testing.T) {
 		}
 
 		var model firewallPolicyResourceModel
-		r.apiToModel(policy, &model, "default")
+		r.apiToModel(&firewallPolicyFull{FirewallPolicy: policy}, &model, "default")
 
 		assert.Equal(t, "CUSTOM", model.ConnectionStateType.ValueString())
 		assert.False(t, model.ConnectionStates.IsNull())
@@ -993,7 +997,7 @@ func TestFirewallPolicyAPIToModel(t *testing.T) {
 		}
 
 		var model firewallPolicyResourceModel
-		r.apiToModel(policy, &model, "default")
+		r.apiToModel(&firewallPolicyFull{FirewallPolicy: policy}, &model, "default")
 
 		assert.Equal(t, "icmpv6", model.Protocol.ValueString())
 		assert.Equal(t, "IPV6", model.IPVersion.ValueString())
@@ -1017,7 +1021,7 @@ func TestFirewallPolicyAPIToModel(t *testing.T) {
 		}
 
 		var model firewallPolicyResourceModel
-		r.apiToModel(policy, &model, "default")
+		r.apiToModel(&firewallPolicyFull{FirewallPolicy: policy}, &model, "default")
 
 		assert.Equal(t, "icmp", model.Protocol.ValueString())
 	})
@@ -1042,7 +1046,15 @@ func TestFirewallPolicyAPIToModel(t *testing.T) {
 		}
 
 		var model firewallPolicyResourceModel
-		r.apiToModel(policy, &model, "default")
+		r.apiToModel(&firewallPolicyFull{
+			FirewallPolicy: policy,
+			RawSchedule: &firewallPolicyScheduleRequest{
+				Mode:           "EVERY_WEEK",
+				TimeRangeStart: "08:00",
+				TimeRangeEnd:   "17:00",
+				RepeatOnDays:   []string{"mon", "fri"},
+			},
+		}, &model, "default")
 
 		assert.False(t, model.Schedule.IsNull())
 	})
@@ -1067,7 +1079,15 @@ func TestFirewallPolicyAPIToModel(t *testing.T) {
 		}
 
 		var model firewallPolicyResourceModel
-		r.apiToModel(policy, &model, "default")
+		r.apiToModel(&firewallPolicyFull{
+			FirewallPolicy: policy,
+			RawSchedule: &firewallPolicyScheduleRequest{
+				Mode:           "ONE_TIME_ONLY",
+				Date:           "2030-01-01",
+				TimeRangeStart: "09:00",
+				TimeRangeEnd:   "12:00",
+			},
+		}, &model, "default")
 
 		assert.False(t, model.Schedule.IsNull())
 		var sched firewallPolicyScheduleModel
@@ -1098,7 +1118,17 @@ func TestFirewallPolicyAPIToModel(t *testing.T) {
 		}
 
 		var model firewallPolicyResourceModel
-		r.apiToModel(policy, &model, "default")
+		r.apiToModel(&firewallPolicyFull{
+			FirewallPolicy: policy,
+			RawSchedule: &firewallPolicyScheduleRequest{
+				Mode:           "CUSTOM",
+				TimeRangeStart: "09:00",
+				TimeRangeEnd:   "12:00",
+				RepeatOnDays:   []string{"mon", "tue", "wed", "thu", "fri", "sat", "sun"},
+				DateRangeStart: "2030-01-01",
+				DateRangeEnd:   "2030-12-31",
+			},
+		}, &model, "default")
 
 		assert.False(t, model.Schedule.IsNull())
 		var sched firewallPolicyScheduleModel
@@ -1107,6 +1137,8 @@ func TestFirewallPolicyAPIToModel(t *testing.T) {
 		assert.Equal(t, "09:00", sched.TimeRangeStart.ValueString())
 		assert.Equal(t, "12:00", sched.TimeRangeEnd.ValueString())
 		assert.Equal(t, 7, len(sched.RepeatOnDays.Elements()))
+		assert.Equal(t, "2030-01-01", sched.DateRangeStart.ValueString())
+		assert.Equal(t, "2030-12-31", sched.DateRangeEnd.ValueString())
 	})
 
 	t.Run("MAC matching target populates mac_addresses", func(t *testing.T) {
@@ -1126,7 +1158,7 @@ func TestFirewallPolicyAPIToModel(t *testing.T) {
 		}
 
 		var model firewallPolicyResourceModel
-		r.apiToModel(policy, &model, "default")
+		r.apiToModel(&firewallPolicyFull{FirewallPolicy: policy}, &model, "default")
 
 		var srcModel firewallPolicyEndpointModel
 		model.Source.As(context.Background(), &srcModel, basetypes.ObjectAsOptions{})
@@ -1157,7 +1189,7 @@ func TestFirewallPolicyAPIToModel(t *testing.T) {
 		}
 
 		var model firewallPolicyResourceModel
-		r.apiToModel(policy, &model, "default")
+		r.apiToModel(&firewallPolicyFull{FirewallPolicy: policy}, &model, "default")
 
 		var srcModel firewallPolicyEndpointModel
 		model.Source.As(context.Background(), &srcModel, basetypes.ObjectAsOptions{})
@@ -1186,7 +1218,7 @@ func TestFirewallPolicyAPIToModel(t *testing.T) {
 		}
 
 		var model firewallPolicyResourceModel
-		r.apiToModel(policy, &model, "default")
+		r.apiToModel(&firewallPolicyFull{FirewallPolicy: policy}, &model, "default")
 
 		var srcModel firewallPolicyEndpointModel
 		model.Source.As(context.Background(), &srcModel, basetypes.ObjectAsOptions{})
@@ -1217,7 +1249,7 @@ func TestFirewallPolicyAPIToModel(t *testing.T) {
 		}
 
 		var model firewallPolicyResourceModel
-		r.apiToModel(policy, &model, "default")
+		r.apiToModel(&firewallPolicyFull{FirewallPolicy: policy}, &model, "default")
 
 		var srcModel firewallPolicyEndpointModel
 		model.Source.As(context.Background(), &srcModel, basetypes.ObjectAsOptions{})
@@ -1249,7 +1281,7 @@ func TestFirewallPolicyAPIToModel(t *testing.T) {
 		}
 
 		var model firewallPolicyResourceModel
-		r.apiToModel(policy, &model, "default")
+		r.apiToModel(&firewallPolicyFull{FirewallPolicy: policy}, &model, "default")
 
 		var srcModel firewallPolicyEndpointModel
 		model.Source.As(context.Background(), &srcModel, basetypes.ObjectAsOptions{})
@@ -1278,7 +1310,7 @@ func TestFirewallPolicyAPIToModel(t *testing.T) {
 		}
 
 		var model firewallPolicyResourceModel
-		r.apiToModel(policy, &model, "default")
+		r.apiToModel(&firewallPolicyFull{FirewallPolicy: policy}, &model, "default")
 
 		var srcModel firewallPolicyEndpointModel
 		model.Source.As(context.Background(), &srcModel, basetypes.ObjectAsOptions{})
@@ -1310,7 +1342,7 @@ func TestFirewallPolicyAPIToModel(t *testing.T) {
 		}
 
 		var model firewallPolicyResourceModel
-		r.apiToModel(policy, &model, "default")
+		r.apiToModel(&firewallPolicyFull{FirewallPolicy: policy}, &model, "default")
 
 		var dstModel firewallPolicyEndpointModel
 		model.Destination.As(context.Background(), &dstModel, basetypes.ObjectAsOptions{})
@@ -1366,6 +1398,8 @@ func TestFirewallPolicyApplyPlanToState(t *testing.T) {
 			"time_range_start": types.StringValue("09:00"),
 			"time_range_end":   types.StringValue("12:00"),
 			"repeat_on_days":   types.SetNull(types.StringType),
+			"date_range_start": types.StringNull(),
+			"date_range_end":   types.StringNull(),
 		})
 		state := &firewallPolicyResourceModel{
 			Name:     types.StringValue("Scheduled Policy"),
@@ -2082,6 +2116,7 @@ resource "terrifi_firewall_policy" "test" {
 		PreCheck:                 func() { preCheck(t); requireHardware(t) },
 		ProtoV6ProviderFactories: testAccProtoV6ProviderFactories,
 		Steps: []resource.TestStep{
+			// All 7 days with date range.
 			{
 				Config: baseConfig(`
   schedule {
@@ -2089,6 +2124,8 @@ resource "terrifi_firewall_policy" "test" {
     time_range_start = "09:00"
     time_range_end   = "12:00"
     repeat_on_days   = ["mon", "tue", "wed", "thu", "fri", "sat", "sun"]
+    date_range_start = "2030-01-01"
+    date_range_end   = "2030-12-31"
   }
 `),
 				Check: resource.ComposeTestCheckFunc(
@@ -2096,9 +2133,11 @@ resource "terrifi_firewall_policy" "test" {
 					resource.TestCheckResourceAttr("terrifi_firewall_policy.test", "schedule.time_range_start", "09:00"),
 					resource.TestCheckResourceAttr("terrifi_firewall_policy.test", "schedule.time_range_end", "12:00"),
 					resource.TestCheckResourceAttr("terrifi_firewall_policy.test", "schedule.repeat_on_days.#", "7"),
+					resource.TestCheckResourceAttr("terrifi_firewall_policy.test", "schedule.date_range_start", "2030-01-01"),
+					resource.TestCheckResourceAttr("terrifi_firewall_policy.test", "schedule.date_range_end", "2030-12-31"),
 				),
 			},
-			// Subset of days.
+			// Subset of days with updated date range.
 			{
 				Config: baseConfig(`
   schedule {
@@ -2106,6 +2145,8 @@ resource "terrifi_firewall_policy" "test" {
     time_range_start = "08:00"
     time_range_end   = "18:00"
     repeat_on_days   = ["mon", "wed", "fri"]
+    date_range_start = "2030-03-01"
+    date_range_end   = "2030-06-30"
   }
 `),
 				Check: resource.ComposeTestCheckFunc(
@@ -2113,6 +2154,8 @@ resource "terrifi_firewall_policy" "test" {
 					resource.TestCheckResourceAttr("terrifi_firewall_policy.test", "schedule.time_range_start", "08:00"),
 					resource.TestCheckResourceAttr("terrifi_firewall_policy.test", "schedule.time_range_end", "18:00"),
 					resource.TestCheckResourceAttr("terrifi_firewall_policy.test", "schedule.repeat_on_days.#", "3"),
+					resource.TestCheckResourceAttr("terrifi_firewall_policy.test", "schedule.date_range_start", "2030-03-01"),
+					resource.TestCheckResourceAttr("terrifi_firewall_policy.test", "schedule.date_range_end", "2030-06-30"),
 				),
 			},
 			{


### PR DESCRIPTION
## Summary

- Adds `date_start` and `date_end` attributes to the `schedule` block in `terrifi_firewall_policy`
- The UniFi API requires these fields when creating or updating a policy with `mode = "CUSTOM"` — without them, the API returns 400 "Missing date range"
- Introduces `firewallPolicyFull` type to carry raw schedule data (including `date_start`/`date_end`) from API responses without loss through the SDK struct, which doesn't have these fields
- Updates `CreateFirewallPolicy`, `UpdateFirewallPolicy`, `GetFirewallPolicy` to return `*firewallPolicyFull`
- Adds `scheduleModelToRequest` to build the schedule payload directly from the Terraform model, bypassing the lossy `unifi.FirewallPolicySchedule` intermediate

## Test plan

- [x] All unit tests pass (`task test:unit`)
- [ ] HIL test `TestAccFirewallPolicy_customSchedule` runs against hardware with `date_start`/`date_end` in all CUSTOM schedule steps
- [ ] HIL test covers: all 7 days with date range, subset of days with updated date range, import, removal

🤖 Generated with [Claude Code](https://claude.com/claude-code)