### PR TITLE
Add config_network block to terrifi_device for setting IP (#136)

### DIFF
--- a/docs/resources/device.md
+++ b/docs/resources/device.md
@@ -54,6 +54,35 @@ resource "terrifi_device" "gateway" {
 }
 ```
 
+### Static management IP
+
+```terraform
+resource "terrifi_device" "core_switch" {
+  mac  = "11:22:33:44:55:66"
+  name = "Core Switch"
+  config_network = {
+    type    = "static"
+    ip      = "192.168.1.5"
+    netmask = "255.255.255.0"
+    gateway = "192.168.1.1"
+    dns1    = "1.1.1.1"
+    dns2    = "8.8.8.8"
+  }
+}
+```
+
+To revert to DHCP, change `type` to `"dhcp"` and remove the addressing fields:
+
+```terraform
+resource "terrifi_device" "core_switch" {
+  mac  = "11:22:33:44:55:66"
+  name = "Core Switch"
+  config_network = {
+    type = "dhcp"
+  }
+}
+```
+
 ### Using with device data source
 
 ```terraform
@@ -88,6 +117,16 @@ resource "terrifi_device" "ap" {
 - `snmp_location` (String) — [SNMP](https://en.wikipedia.org/wiki/Simple_Network_Management_Protocol) location string (max 255 characters). Describes where the device is physically located; read by network monitoring tools.
 - `volume` (Number) — Speaker volume (0–100). Only applicable to devices with speakers.
 - `site` (String) — The site the device belongs to. Defaults to the provider site. Changing this forces a new resource.
+- `config_network` (Block) — Management network configuration. Omit to leave the device's current configuration untouched. See [below](#config_network).
+
+### config_network
+
+- `type` (String, Required) — Addressing mode: `dhcp` or `static`.
+- `ip` (String) — Static IPv4 address. Required when `type = "static"`; must not be set when `type = "dhcp"`.
+- `netmask` (String) — Subnet mask (e.g. `255.255.255.0`). Required when `type = "static"`.
+- `gateway` (String) — Default gateway IPv4 address. Required when `type = "static"`.
+- `dns1` (String) — Primary DNS server.
+- `dns2` (String) — Secondary DNS server.
 
 ### Read-Only
 

--- a/internal/generate/device.go
+++ b/internal/generate/device.go
@@ -1,6 +1,9 @@
 package generate
 
 import (
+	"fmt"
+	"strings"
+
 	"github.com/ubiquiti-community/go-unifi/unifi"
 )
 
@@ -57,9 +60,41 @@ func DeviceBlocks(devices []unifi.Device) []ResourceBlock {
 		if d.Volume != nil {
 			block.Attributes = append(block.Attributes, Attr{Key: "volume", Value: HCLInt64(*d.Volume)})
 		}
+		if v := formatDeviceConfigNetwork(d.ConfigNetwork); v != "" {
+			block.Attributes = append(block.Attributes, Attr{Key: "config_network", Value: v})
+		}
 
 		blocks = append(blocks, block)
 	}
 	DeduplicateNames(blocks)
 	return blocks
+}
+
+// formatDeviceConfigNetwork renders the device's config_network as a nested
+// HCL object literal (for use as an Attribute value). Returns an empty string
+// when the device has no explicit configuration, so the attribute is omitted.
+func formatDeviceConfigNetwork(cn *unifi.DeviceConfigNetwork) string {
+	if cn == nil || cn.Type == "" {
+		return ""
+	}
+	var lines []string
+	lines = append(lines, fmt.Sprintf("    type    = %s", HCLString(cn.Type)))
+	if cn.Type == "static" {
+		if cn.IP != "" {
+			lines = append(lines, fmt.Sprintf("    ip      = %s", HCLString(cn.IP)))
+		}
+		if cn.Netmask != "" {
+			lines = append(lines, fmt.Sprintf("    netmask = %s", HCLString(cn.Netmask)))
+		}
+		if cn.Gateway != "" {
+			lines = append(lines, fmt.Sprintf("    gateway = %s", HCLString(cn.Gateway)))
+		}
+		if cn.DNS1 != "" {
+			lines = append(lines, fmt.Sprintf("    dns1    = %s", HCLString(cn.DNS1)))
+		}
+		if cn.DNS2 != "" {
+			lines = append(lines, fmt.Sprintf("    dns2    = %s", HCLString(cn.DNS2)))
+		}
+	}
+	return "{\n" + strings.Join(lines, "\n") + "\n  }"
 }

--- a/internal/provider/device_api.go
+++ b/internal/provider/device_api.go
@@ -27,16 +27,26 @@ import (
 // By sending only these fields, we avoid the SDK's diff mechanism which
 // produces spurious changes from stat counters and other runtime fields.
 type deviceUpdatePayload struct {
-	Name                       string `json:"name"`
-	LedOverride                string `json:"led_override,omitempty"`
-	LedOverrideColor           string `json:"led_override_color,omitempty"`
-	LedOverrideColorBrightness *int64 `json:"led_override_color_brightness,omitempty"`
-	OutdoorModeOverride        string `json:"outdoor_mode_override,omitempty"`
-	Locked                     bool   `json:"locked"`
-	Disabled                   bool   `json:"disabled"`
-	SnmpContact                string `json:"snmp_contact,omitempty"`
-	SnmpLocation               string `json:"snmp_location,omitempty"`
-	Volume                     *int64 `json:"volume,omitempty"`
+	Name                       string                      `json:"name"`
+	LedOverride                string                      `json:"led_override,omitempty"`
+	LedOverrideColor           string                      `json:"led_override_color,omitempty"`
+	LedOverrideColorBrightness *int64                      `json:"led_override_color_brightness,omitempty"`
+	OutdoorModeOverride        string                      `json:"outdoor_mode_override,omitempty"`
+	Locked                     bool                        `json:"locked"`
+	Disabled                   bool                        `json:"disabled"`
+	SnmpContact                string                      `json:"snmp_contact,omitempty"`
+	SnmpLocation               string                      `json:"snmp_location,omitempty"`
+	Volume                     *int64                      `json:"volume,omitempty"`
+	ConfigNetwork              *deviceConfigNetworkPayload `json:"config_network,omitempty"`
+}
+
+type deviceConfigNetworkPayload struct {
+	Type    string `json:"type"`
+	IP      string `json:"ip,omitempty"`
+	Netmask string `json:"netmask,omitempty"`
+	Gateway string `json:"gateway,omitempty"`
+	DNS1    string `json:"dns1,omitempty"`
+	DNS2    string `json:"dns2,omitempty"`
 }
 
 // UpdateDevice sends a PUT to the UniFi REST API with only the managed fields.
@@ -88,6 +98,17 @@ func (c *Client) UpdateDevice(ctx context.Context, site string, id string, m *de
 	if !m.Volume.IsNull() && !m.Volume.IsUnknown() {
 		v := m.Volume.ValueInt64()
 		payload.Volume = &v
+	}
+
+	if m.ConfigNetwork != nil {
+		payload.ConfigNetwork = &deviceConfigNetworkPayload{
+			Type:    m.ConfigNetwork.Type.ValueString(),
+			IP:      m.ConfigNetwork.IP.ValueString(),
+			Netmask: m.ConfigNetwork.Netmask.ValueString(),
+			Gateway: m.ConfigNetwork.Gateway.ValueString(),
+			DNS1:    m.ConfigNetwork.DNS1.ValueString(),
+			DNS2:    m.ConfigNetwork.DNS2.ValueString(),
+		}
 	}
 
 	// Use the v1 REST API endpoint for device updates.

--- a/internal/provider/device_resource.go
+++ b/internal/provider/device_resource.go
@@ -24,8 +24,9 @@ import (
 var ledColorRegexp = regexp.MustCompile(`^#(?:[0-9a-fA-F]{3}){1,2}$`)
 
 var (
-	_ resource.Resource                = &deviceResource{}
-	_ resource.ResourceWithImportState = &deviceResource{}
+	_ resource.Resource                     = &deviceResource{}
+	_ resource.ResourceWithImportState      = &deviceResource{}
+	_ resource.ResourceWithConfigValidators = &deviceResource{}
 )
 
 func NewDeviceResource() resource.Resource {
@@ -37,25 +38,35 @@ type deviceResource struct {
 }
 
 type deviceResourceModel struct {
-	ID                        types.String `tfsdk:"id"`
-	Site                      types.String `tfsdk:"site"`
-	MAC                       types.String `tfsdk:"mac"`
-	Name                      types.String `tfsdk:"name"`
-	LedEnabled               types.Bool   `tfsdk:"led_enabled"`
-	LedColor          types.String `tfsdk:"led_color"`
-	LedBrightness types.Int64  `tfsdk:"led_brightness"`
-	OutdoorModeOverride       types.String `tfsdk:"outdoor_mode_override"`
-	Locked                    types.Bool   `tfsdk:"locked"`
-	Disabled                  types.Bool   `tfsdk:"disabled"`
-	SnmpContact               types.String `tfsdk:"snmp_contact"`
-	SnmpLocation              types.String `tfsdk:"snmp_location"`
-	Volume                    types.Int64  `tfsdk:"volume"`
+	ID                  types.String              `tfsdk:"id"`
+	Site                types.String              `tfsdk:"site"`
+	MAC                 types.String              `tfsdk:"mac"`
+	Name                types.String              `tfsdk:"name"`
+	LedEnabled          types.Bool                `tfsdk:"led_enabled"`
+	LedColor            types.String              `tfsdk:"led_color"`
+	LedBrightness       types.Int64               `tfsdk:"led_brightness"`
+	OutdoorModeOverride types.String              `tfsdk:"outdoor_mode_override"`
+	Locked              types.Bool                `tfsdk:"locked"`
+	Disabled            types.Bool                `tfsdk:"disabled"`
+	SnmpContact         types.String              `tfsdk:"snmp_contact"`
+	SnmpLocation        types.String              `tfsdk:"snmp_location"`
+	Volume              types.Int64               `tfsdk:"volume"`
+	ConfigNetwork       *deviceConfigNetworkModel `tfsdk:"config_network"`
 	// Computed/read-only.
 	Model   types.String `tfsdk:"model"`
 	Type    types.String `tfsdk:"type"`
 	IP      types.String `tfsdk:"ip"`
 	Adopted types.Bool   `tfsdk:"adopted"`
 	State   types.Int64  `tfsdk:"state"`
+}
+
+type deviceConfigNetworkModel struct {
+	Type    types.String `tfsdk:"type"`
+	IP      types.String `tfsdk:"ip"`
+	Netmask types.String `tfsdk:"netmask"`
+	Gateway types.String `tfsdk:"gateway"`
+	DNS1    types.String `tfsdk:"dns1"`
+	DNS2    types.String `tfsdk:"dns2"`
 }
 
 func (r *deviceResource) Metadata(
@@ -167,7 +178,7 @@ func (r *deviceResource) Schema(
 			"snmp_contact": schema.StringAttribute{
 				MarkdownDescription: "[SNMP](https://en.wikipedia.org/wiki/Simple_Network_Management_Protocol) contact string (max 255 characters). " +
 					"Identifies who is responsible for the device; read by network monitoring tools.",
-				Optional:            true,
+				Optional: true,
 				Validators: []validator.String{
 					stringvalidator.LengthAtMost(255),
 				},
@@ -176,7 +187,7 @@ func (r *deviceResource) Schema(
 			"snmp_location": schema.StringAttribute{
 				MarkdownDescription: "[SNMP](https://en.wikipedia.org/wiki/Simple_Network_Management_Protocol) location string (max 255 characters). " +
 					"Describes where the device is physically located; read by network monitoring tools.",
-				Optional:            true,
+				Optional: true,
 				Validators: []validator.String{
 					stringvalidator.LengthAtMost(255),
 				},
@@ -187,6 +198,43 @@ func (r *deviceResource) Schema(
 				Optional:            true,
 				Validators: []validator.Int64{
 					int64validator.Between(0, 100),
+				},
+			},
+
+			"config_network": schema.SingleNestedAttribute{
+				MarkdownDescription: "Management network configuration for the device. " +
+					"Use `type = \"dhcp\"` to receive an address from DHCP, or `type = \"static\"` " +
+					"with `ip`, `netmask`, and `gateway` set to assign a fixed management address. " +
+					"Omit this block to leave the device's current configuration unchanged.",
+				Optional: true,
+				Attributes: map[string]schema.Attribute{
+					"type": schema.StringAttribute{
+						MarkdownDescription: "Addressing mode: `dhcp` or `static`.",
+						Required:            true,
+						Validators: []validator.String{
+							stringvalidator.OneOf("dhcp", "static"),
+						},
+					},
+					"ip": schema.StringAttribute{
+						MarkdownDescription: "Static IPv4 address. Required when `type = static`.",
+						Optional:            true,
+					},
+					"netmask": schema.StringAttribute{
+						MarkdownDescription: "Subnet mask (e.g. `255.255.255.0`). Required when `type = static`.",
+						Optional:            true,
+					},
+					"gateway": schema.StringAttribute{
+						MarkdownDescription: "Default gateway IPv4 address. Required when `type = static`.",
+						Optional:            true,
+					},
+					"dns1": schema.StringAttribute{
+						MarkdownDescription: "Primary DNS server.",
+						Optional:            true,
+					},
+					"dns2": schema.StringAttribute{
+						MarkdownDescription: "Secondary DNS server.",
+						Optional:            true,
+					},
 				},
 			},
 
@@ -232,6 +280,12 @@ func (r *deviceResource) Schema(
 				},
 			},
 		},
+	}
+}
+
+func (r *deviceResource) ConfigValidators(_ context.Context) []resource.ConfigValidator {
+	return []resource.ConfigValidator{
+		deviceConfigNetworkValidator{},
 	}
 }
 
@@ -460,8 +514,28 @@ func (r *deviceResource) preserveNullOptionals(plan, state *deviceResourceModel)
 	if plan.Volume.IsNull() {
 		state.Volume = types.Int64Null()
 	}
+	if plan.ConfigNetwork == nil {
+		state.ConfigNetwork = nil
+	} else if state.ConfigNetwork != nil {
+		// Preserve null sub-fields the user didn't configure so Terraform
+		// doesn't see spurious diffs for values the API fills in by default.
+		if plan.ConfigNetwork.IP.IsNull() {
+			state.ConfigNetwork.IP = types.StringNull()
+		}
+		if plan.ConfigNetwork.Netmask.IsNull() {
+			state.ConfigNetwork.Netmask = types.StringNull()
+		}
+		if plan.ConfigNetwork.Gateway.IsNull() {
+			state.ConfigNetwork.Gateway = types.StringNull()
+		}
+		if plan.ConfigNetwork.DNS1.IsNull() {
+			state.ConfigNetwork.DNS1 = types.StringNull()
+		}
+		if plan.ConfigNetwork.DNS2.IsNull() {
+			state.ConfigNetwork.DNS2 = types.StringNull()
+		}
+	}
 }
-
 
 func (r *deviceResource) apiToModel(d *unifi.Device, m *deviceResourceModel, site string) {
 	m.ID = types.StringValue(d.ID)
@@ -494,10 +568,82 @@ func (r *deviceResource) apiToModel(d *unifi.Device, m *deviceResourceModel, sit
 		m.Volume = types.Int64Null()
 	}
 
+	if d.ConfigNetwork != nil && d.ConfigNetwork.Type != "" {
+		m.ConfigNetwork = &deviceConfigNetworkModel{
+			Type:    types.StringValue(d.ConfigNetwork.Type),
+			IP:      stringValueOrNull(d.ConfigNetwork.IP),
+			Netmask: stringValueOrNull(d.ConfigNetwork.Netmask),
+			Gateway: stringValueOrNull(d.ConfigNetwork.Gateway),
+			DNS1:    stringValueOrNull(d.ConfigNetwork.DNS1),
+			DNS2:    stringValueOrNull(d.ConfigNetwork.DNS2),
+		}
+	} else {
+		m.ConfigNetwork = nil
+	}
+
 	// Read-only fields.
 	m.Model = stringValueOrNull(d.Model)
 	m.Type = stringValueOrNull(d.Type)
 	m.IP = stringValueOrNull(d.IP)
 	m.Adopted = types.BoolValue(d.Adopted)
 	m.State = types.Int64Value(int64(d.State))
+}
+
+// ---------------------------------------------------------------------------
+// Config validators
+// ---------------------------------------------------------------------------
+
+// deviceConfigNetworkValidator ensures that when config_network.type is
+// "static", the required addressing fields (ip, netmask, gateway) are set.
+type deviceConfigNetworkValidator struct{}
+
+func (v deviceConfigNetworkValidator) Description(_ context.Context) string {
+	return "When config_network.type is \"static\", ip, netmask, and gateway must be set."
+}
+
+func (v deviceConfigNetworkValidator) MarkdownDescription(ctx context.Context) string {
+	return v.Description(ctx)
+}
+
+func (v deviceConfigNetworkValidator) ValidateResource(ctx context.Context, req resource.ValidateConfigRequest, resp *resource.ValidateConfigResponse) {
+	var cfg *deviceConfigNetworkModel
+	resp.Diagnostics.Append(req.Config.GetAttribute(ctx, path.Root("config_network"), &cfg)...)
+	if resp.Diagnostics.HasError() || cfg == nil {
+		return
+	}
+
+	if cfg.Type.IsNull() || cfg.Type.IsUnknown() {
+		return
+	}
+
+	switch cfg.Type.ValueString() {
+	case "static":
+		for name, v := range map[string]types.String{
+			"ip":      cfg.IP,
+			"netmask": cfg.Netmask,
+			"gateway": cfg.Gateway,
+		} {
+			if v.IsNull() {
+				resp.Diagnostics.AddAttributeError(
+					path.Root("config_network").AtName(name),
+					"Missing required attribute",
+					fmt.Sprintf("config_network.%s is required when config_network.type is \"static\".", name),
+				)
+			}
+		}
+	case "dhcp":
+		for name, v := range map[string]types.String{
+			"ip":      cfg.IP,
+			"netmask": cfg.Netmask,
+			"gateway": cfg.Gateway,
+		} {
+			if !v.IsNull() && !v.IsUnknown() {
+				resp.Diagnostics.AddAttributeError(
+					path.Root("config_network").AtName(name),
+					"Attribute not allowed",
+					fmt.Sprintf("config_network.%s must not be set when config_network.type is \"dhcp\".", name),
+				)
+			}
+		}
+	}
 }

--- a/internal/provider/device_resource_test.go
+++ b/internal/provider/device_resource_test.go
@@ -6,8 +6,10 @@ import (
 	"regexp"
 	"testing"
 
+	"github.com/hashicorp/terraform-plugin-framework/types"
 	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 	"github.com/ubiquiti-community/go-unifi/unifi"
 )
 
@@ -26,17 +28,17 @@ func TestDeviceUpdatePayload(t *testing.T) {
 			ID:                         "dev-123",
 			MAC:                        "aa:bb:cc:dd:ee:ff",
 			Name:                       "Office AP",
-			LedOverride:               "on",
-			LedOverrideColor:          "#ff0000",
+			LedOverride:                "on",
+			LedOverrideColor:           "#ff0000",
 			LedOverrideColorBrightness: &brightness,
-			OutdoorModeOverride:       "off",
-			Locked:                    true,
-			Disabled:                  false,
-			SnmpContact:              "admin@test.com",
-			SnmpLocation:             "Building A",
-			Volume:                   &volume,
-			Adopted:                  true,
-			State:                    unifi.DeviceStateConnected,
+			OutdoorModeOverride:        "off",
+			Locked:                     true,
+			Disabled:                   false,
+			SnmpContact:                "admin@test.com",
+			SnmpLocation:               "Building A",
+			Volume:                     &volume,
+			Adopted:                    true,
+			State:                      unifi.DeviceStateConnected,
 		}
 
 		var m deviceResourceModel
@@ -81,15 +83,15 @@ func TestDeviceResourceAPIToModel(t *testing.T) {
 			IP:                         "192.168.1.10",
 			Adopted:                    true,
 			State:                      unifi.DeviceStateConnected,
-			LedOverride:               "on",
-			LedOverrideColor:          "#ff0000",
+			LedOverride:                "on",
+			LedOverrideColor:           "#ff0000",
 			LedOverrideColorBrightness: &brightness,
-			OutdoorModeOverride:       "off",
-			Locked:                    true,
-			Disabled:                  false,
-			SnmpContact:              "admin@test.com",
-			SnmpLocation:             "Building A",
-			Volume:                   &volume,
+			OutdoorModeOverride:        "off",
+			Locked:                     true,
+			Disabled:                   false,
+			SnmpContact:                "admin@test.com",
+			SnmpLocation:               "Building A",
+			Volume:                     &volume,
 		}
 
 		var m deviceResourceModel
@@ -162,6 +164,73 @@ func TestDeviceResourceAPIToModel(t *testing.T) {
 	})
 }
 
+func TestDeviceResourceAPIToModelConfigNetwork(t *testing.T) {
+	r := &deviceResource{}
+
+	t.Run("static config network", func(t *testing.T) {
+		dev := &unifi.Device{
+			ID:  "dev-cn-static",
+			MAC: "aa:bb:cc:dd:ee:ff",
+			ConfigNetwork: &unifi.DeviceConfigNetwork{
+				Type:    "static",
+				IP:      "192.168.1.50",
+				Netmask: "255.255.255.0",
+				Gateway: "192.168.1.1",
+				DNS1:    "1.1.1.1",
+				DNS2:    "8.8.8.8",
+			},
+		}
+
+		var m deviceResourceModel
+		r.apiToModel(dev, &m, "default")
+
+		require.NotNil(t, m.ConfigNetwork)
+		assert.Equal(t, "static", m.ConfigNetwork.Type.ValueString())
+		assert.Equal(t, "192.168.1.50", m.ConfigNetwork.IP.ValueString())
+		assert.Equal(t, "255.255.255.0", m.ConfigNetwork.Netmask.ValueString())
+		assert.Equal(t, "192.168.1.1", m.ConfigNetwork.Gateway.ValueString())
+		assert.Equal(t, "1.1.1.1", m.ConfigNetwork.DNS1.ValueString())
+		assert.Equal(t, "8.8.8.8", m.ConfigNetwork.DNS2.ValueString())
+	})
+
+	t.Run("dhcp config network", func(t *testing.T) {
+		dev := &unifi.Device{
+			ID:            "dev-cn-dhcp",
+			MAC:           "aa:bb:cc:dd:ee:ff",
+			ConfigNetwork: &unifi.DeviceConfigNetwork{Type: "dhcp"},
+		}
+
+		var m deviceResourceModel
+		r.apiToModel(dev, &m, "default")
+
+		require.NotNil(t, m.ConfigNetwork)
+		assert.Equal(t, "dhcp", m.ConfigNetwork.Type.ValueString())
+		assert.True(t, m.ConfigNetwork.IP.IsNull())
+		assert.True(t, m.ConfigNetwork.Netmask.IsNull())
+		assert.True(t, m.ConfigNetwork.Gateway.IsNull())
+	})
+
+	t.Run("nil config network", func(t *testing.T) {
+		dev := &unifi.Device{ID: "dev-cn-nil", MAC: "aa:bb:cc:dd:ee:ff"}
+
+		var m deviceResourceModel
+		r.apiToModel(dev, &m, "default")
+
+		assert.Nil(t, m.ConfigNetwork)
+	})
+
+	t.Run("preserveNullOptionals nils state when plan is nil", func(t *testing.T) {
+		plan := deviceResourceModel{}
+		state := deviceResourceModel{
+			ConfigNetwork: &deviceConfigNetworkModel{
+				Type: types.StringValue("dhcp"),
+			},
+		}
+		r.preserveNullOptionals(&plan, &state)
+		assert.Nil(t, state.ConfigNetwork)
+	})
+}
+
 func TestDeviceResourceAPIToModelRoundTrip(t *testing.T) {
 	r := &deviceResource{}
 
@@ -171,20 +240,20 @@ func TestDeviceResourceAPIToModelRoundTrip(t *testing.T) {
 		ID:                         "dev-rt",
 		MAC:                        "aa:bb:cc:dd:ee:ff",
 		Name:                       "Round Trip",
-		LedOverride:               "on",
-		LedOverrideColor:          "#00ff00",
+		LedOverride:                "on",
+		LedOverrideColor:           "#00ff00",
 		LedOverrideColorBrightness: &brightness,
-		OutdoorModeOverride:       "on",
-		Locked:                    true,
-		Disabled:                  false,
-		SnmpContact:              "ops@example.com",
-		SnmpLocation:             "DC1",
-		Volume:                   &volume,
-		Model:                    "USW-24",
-		Type:                     "usw",
-		IP:                       "10.0.0.1",
-		Adopted:                  true,
-		State:                    unifi.DeviceStateConnected,
+		OutdoorModeOverride:        "on",
+		Locked:                     true,
+		Disabled:                   false,
+		SnmpContact:                "ops@example.com",
+		SnmpLocation:               "DC1",
+		Volume:                     &volume,
+		Model:                      "USW-24",
+		Type:                       "usw",
+		IP:                         "10.0.0.1",
+		Adopted:                    true,
+		State:                      unifi.DeviceStateConnected,
 	}
 
 	// API → model → verify model correctly represents the API data.
@@ -766,6 +835,133 @@ resource "terrifi_device" "test" {
 	})
 }
 
+// TestAccDeviceResource_configNetworkDHCP sets the management network to DHCP
+// and verifies the round trip. DHCP is always safe to apply since it won't
+// disrupt controller connectivity.
+func TestAccDeviceResource_configNetworkDHCP(t *testing.T) {
+	if os.Getenv("TF_ACC") == "" {
+		t.Skip("TF_ACC not set")
+	}
+	preCheck(t)
+	requireAdoptedDevice(t)
+
+	dev := findFirstAdoptedDevice(t)
+	resource.Test(t, resource.TestCase{
+		ProtoV6ProviderFactories: testAccProtoV6ProviderFactories,
+		Steps: []resource.TestStep{
+			{
+				Config: fmt.Sprintf(`
+resource "terrifi_device" "test" {
+  mac  = %q
+  name = "tfacc-device-cn-dhcp"
+  config_network = {
+    type = "dhcp"
+  }
+}
+`, dev.MAC),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr("terrifi_device.test", "config_network.type", "dhcp"),
+				),
+			},
+			// Idempotent re-apply.
+			{
+				Config: fmt.Sprintf(`
+resource "terrifi_device" "test" {
+  mac  = %q
+  name = "tfacc-device-cn-dhcp"
+  config_network = {
+    type = "dhcp"
+  }
+}
+`, dev.MAC),
+			},
+			// Remove config_network — device keeps whatever the controller set.
+			{
+				Config: fmt.Sprintf(`
+resource "terrifi_device" "test" {
+  mac  = %q
+  name = "tfacc-device-cn-dhcp"
+}
+`, dev.MAC),
+				Check: resource.TestCheckNoResourceAttr("terrifi_device.test", "config_network"),
+			},
+		},
+	})
+}
+
+// TestAccDeviceResource_configNetworkStatic assigns a static management IP and
+// reverts to DHCP. Skipped unless TERRIFI_ACC_DEVICE_STATIC_IP, _NETMASK, and
+// _GATEWAY are all set — applying a wrong static IP would sever the controller's
+// connection to the device.
+func TestAccDeviceResource_configNetworkStatic(t *testing.T) {
+	if os.Getenv("TF_ACC") == "" {
+		t.Skip("TF_ACC not set")
+	}
+	staticIP := os.Getenv("TERRIFI_ACC_DEVICE_STATIC_IP")
+	netmask := os.Getenv("TERRIFI_ACC_DEVICE_STATIC_NETMASK")
+	gateway := os.Getenv("TERRIFI_ACC_DEVICE_STATIC_GATEWAY")
+	if staticIP == "" || netmask == "" || gateway == "" {
+		t.Skip("TERRIFI_ACC_DEVICE_STATIC_IP/NETMASK/GATEWAY not set — skipping static IP test")
+	}
+	preCheck(t)
+	requireAdoptedDevice(t)
+
+	dev := findFirstAdoptedDevice(t)
+	resource.Test(t, resource.TestCase{
+		ProtoV6ProviderFactories: testAccProtoV6ProviderFactories,
+		Steps: []resource.TestStep{
+			{
+				Config: fmt.Sprintf(`
+resource "terrifi_device" "test" {
+  mac  = %q
+  name = "tfacc-device-cn-static"
+  config_network = {
+    type    = "static"
+    ip      = %q
+    netmask = %q
+    gateway = %q
+  }
+}
+`, dev.MAC, staticIP, netmask, gateway),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr("terrifi_device.test", "config_network.type", "static"),
+					resource.TestCheckResourceAttr("terrifi_device.test", "config_network.ip", staticIP),
+					resource.TestCheckResourceAttr("terrifi_device.test", "config_network.netmask", netmask),
+					resource.TestCheckResourceAttr("terrifi_device.test", "config_network.gateway", gateway),
+				),
+			},
+			// Idempotent.
+			{
+				Config: fmt.Sprintf(`
+resource "terrifi_device" "test" {
+  mac  = %q
+  name = "tfacc-device-cn-static"
+  config_network = {
+    type    = "static"
+    ip      = %q
+    netmask = %q
+    gateway = %q
+  }
+}
+`, dev.MAC, staticIP, netmask, gateway),
+			},
+			// Revert to DHCP.
+			{
+				Config: fmt.Sprintf(`
+resource "terrifi_device" "test" {
+  mac  = %q
+  name = "tfacc-device-cn-static"
+  config_network = {
+    type = "dhcp"
+  }
+}
+`, dev.MAC),
+				Check: resource.TestCheckResourceAttr("terrifi_device.test", "config_network.type", "dhcp"),
+			},
+		},
+	})
+}
+
 // TestAccDeviceResource_computedFieldsStable verifies computed read-only fields
 // don't cause spurious diffs across multiple applies.
 func TestAccDeviceResource_computedFieldsStable(t *testing.T) {
@@ -824,7 +1020,6 @@ resource "terrifi_device" "test" {
 	})
 }
 
-
 func TestAccDeviceResource_validationInvalidLedColor(t *testing.T) {
 	resource.Test(t, resource.TestCase{
 		PreCheck:                 func() { preCheck(t) },
@@ -838,6 +1033,67 @@ resource "terrifi_device" "test" {
 }
 `,
 				ExpectError: regexp.MustCompile(`must be a hex color`),
+			},
+		},
+	})
+}
+
+func TestAccDeviceResource_validationStaticRequiresAddressing(t *testing.T) {
+	resource.Test(t, resource.TestCase{
+		PreCheck:                 func() { preCheck(t) },
+		ProtoV6ProviderFactories: testAccProtoV6ProviderFactories,
+		Steps: []resource.TestStep{
+			{
+				Config: `
+resource "terrifi_device" "test" {
+  mac = "aa:bb:cc:dd:ee:ff"
+  config_network = {
+    type = "static"
+  }
+}
+`,
+				ExpectError: regexp.MustCompile(`required when config_network\.type is "static"`),
+			},
+		},
+	})
+}
+
+func TestAccDeviceResource_validationDHCPRejectsAddressing(t *testing.T) {
+	resource.Test(t, resource.TestCase{
+		PreCheck:                 func() { preCheck(t) },
+		ProtoV6ProviderFactories: testAccProtoV6ProviderFactories,
+		Steps: []resource.TestStep{
+			{
+				Config: `
+resource "terrifi_device" "test" {
+  mac = "aa:bb:cc:dd:ee:ff"
+  config_network = {
+    type = "dhcp"
+    ip   = "192.168.1.50"
+  }
+}
+`,
+				ExpectError: regexp.MustCompile(`must not be set when config_network\.type is "dhcp"`),
+			},
+		},
+	})
+}
+
+func TestAccDeviceResource_validationInvalidConfigNetworkType(t *testing.T) {
+	resource.Test(t, resource.TestCase{
+		PreCheck:                 func() { preCheck(t) },
+		ProtoV6ProviderFactories: testAccProtoV6ProviderFactories,
+		Steps: []resource.TestStep{
+			{
+				Config: `
+resource "terrifi_device" "test" {
+  mac = "aa:bb:cc:dd:ee:ff"
+  config_network = {
+    type = "auto"
+  }
+}
+`,
+				ExpectError: regexp.MustCompile(`must be one of`),
 			},
 		},
 	})


### PR DESCRIPTION
## Summary
- Adds `config_network` nested attribute to `terrifi_device` with `type` (`dhcp` / `static`) and `ip`, `netmask`, `gateway`, `dns1`, `dns2`.
- Config validator enforces that `static` requires `ip`/`netmask`/`gateway` and `dhcp` forbids them.
- `generate-imports` now emits `config_network` for devices with an explicit configuration.
- Docs updated with static + DHCP examples and schema entry.

Closes #136.

## Test plan
- [x] `go test ./internal/...` — unit tests for static, DHCP, nil, and `preserveNullOptionals` round trips pass.
- [x] `TF_ACC=1 go test ./internal/provider/ -run TestAccDeviceResource_validation...` — three config-network validation tests pass against the Docker controller.
- [ ] Manual HIL: `TestAccDeviceResource_configNetworkDHCP` (safe) and `TestAccDeviceResource_configNetworkStatic` (gated on `TERRIFI_ACC_DEVICE_STATIC_IP/NETMASK/GATEWAY` so a wrong static IP can't sever the controller's connection to the device).

🤖 Generated with [Claude Code](https://claude.com/claude-code)