### PR TITLE
Add application and optimize_iot_connectivity to terrifi_wlan

### DIFF
--- a/docs/resources/wlan.md
+++ b/docs/resources/wlan.md
@@ -94,6 +94,8 @@ resource "terrifi_wlan" "maintenance" {
 - `wpa_mode` (String) — The WPA mode. Must be `auto` or `wpa2`. Defaults to `wpa2`.
 - `wpa3_support` (Boolean) — Whether to enable WPA3 support. Defaults to `false`.
 - `wpa3_transition` (Boolean) — Whether to enable WPA3 transition mode (WPA2/WPA3 mixed). Defaults to `false`.
+- `application` (String) — The application type. Must be `standard`, `hotspot`, or `iot`. `hotspot` enables guest behavior (captive portal); `iot` enables IoT-optimized behavior. Defaults to `standard`.
+- `optimize_iot_connectivity` (Boolean) — Enable IoT-specific radio optimizations that improve connection reliability for IoT devices. Only meaningful when `application = "iot"`. Defaults to `false`.
 - `site` (String) — The site to associate the WLAN with. Defaults to the provider site. Changing this forces a new resource.
 
 ### Read-Only

--- a/docs/resources/wlan.md
+++ b/docs/resources/wlan.md
@@ -96,6 +96,8 @@ resource "terrifi_wlan" "maintenance" {
 - `wpa3_transition` (Boolean) — Whether to enable WPA3 transition mode (WPA2/WPA3 mixed). Defaults to `false`.
 - `application` (String) — The application type. Must be `standard`, `hotspot`, or `iot`. `hotspot` enables guest behavior (captive portal); `iot` enables IoT-optimized behavior. Defaults to `standard`.
 - `optimize_iot_connectivity` (Boolean) — Enable IoT-specific radio optimizations that improve connection reliability for IoT devices. Only meaningful when `application = "iot"`. Defaults to `false`.
+
+~> **Note:** The UniFi controller coerces iot WLANs (especially with `optimize_iot_connectivity = true`) to the 2.4 GHz band. Set `wifi_band = "2g"` explicitly when using `application = "iot"` to avoid inconsistent-plan errors.
 - `site` (String) — The site to associate the WLAN with. Defaults to the provider site. Changing this forces a new resource.
 
 ### Read-Only

--- a/internal/generate/wlan.go
+++ b/internal/generate/wlan.go
@@ -47,6 +47,15 @@ func WLANBlocks(wlans []unifi.WLAN) []ResourceBlock {
 		if w.WPA3Transition {
 			block.Attributes = append(block.Attributes, Attr{Key: "wpa3_transition", Value: HCLBool(true)})
 		}
+		switch {
+		case w.IsGuest:
+			block.Attributes = append(block.Attributes, Attr{Key: "application", Value: HCLString("hotspot")})
+		case w.EnhancedIot:
+			block.Attributes = append(block.Attributes, Attr{Key: "application", Value: HCLString("iot")})
+		}
+		if w.OptimizeIotWifiConnectivity {
+			block.Attributes = append(block.Attributes, Attr{Key: "optimize_iot_connectivity", Value: HCLBool(true)})
+		}
 
 		blocks = append(blocks, block)
 	}

--- a/internal/provider/wlan_resource.go
+++ b/internal/provider/wlan_resource.go
@@ -42,8 +42,10 @@ type wlanResourceModel struct {
 	Security       types.String `tfsdk:"security"`
 	HideSSID       types.Bool   `tfsdk:"hide_ssid"`
 	WPAMode        types.String `tfsdk:"wpa_mode"`
-	WPA3Support    types.Bool   `tfsdk:"wpa3_support"`
-	WPA3Transition types.Bool   `tfsdk:"wpa3_transition"`
+	WPA3Support             types.Bool   `tfsdk:"wpa3_support"`
+	WPA3Transition          types.Bool   `tfsdk:"wpa3_transition"`
+	Application             types.String `tfsdk:"application"`
+	OptimizeIoTConnectivity types.Bool   `tfsdk:"optimize_iot_connectivity"`
 }
 
 func (r *wlanResource) Metadata(
@@ -159,6 +161,26 @@ func (r *wlanResource) Schema(
 				Optional:            true,
 				Computed:            true,
 				Default:             booldefault.StaticBool(false),
+			},
+
+			"application": schema.StringAttribute{
+				MarkdownDescription: "The application type for this WLAN. Must be `standard`, `hotspot`, or `iot`. " +
+					"`hotspot` enables guest behavior (captive portal); `iot` enables IoT-optimized behavior. " +
+					"Default: `standard`.",
+				Optional: true,
+				Computed: true,
+				Default:  stringdefault.StaticString("standard"),
+				Validators: []validator.String{
+					stringvalidator.OneOf("standard", "hotspot", "iot"),
+				},
+			},
+
+			"optimize_iot_connectivity": schema.BoolAttribute{
+				MarkdownDescription: "Enable IoT-specific radio optimizations that improve connection reliability " +
+					"for IoT devices. Only meaningful when `application = \"iot\"`. Default: `false`.",
+				Optional: true,
+				Computed: true,
+				Default:  booldefault.StaticBool(false),
 			},
 		},
 	}
@@ -416,6 +438,12 @@ func (r *wlanResource) applyPlanToState(plan, state *wlanResourceModel) {
 	if !plan.WPA3Transition.IsNull() && !plan.WPA3Transition.IsUnknown() {
 		state.WPA3Transition = plan.WPA3Transition
 	}
+	if !plan.Application.IsNull() && !plan.Application.IsUnknown() {
+		state.Application = plan.Application
+	}
+	if !plan.OptimizeIoTConnectivity.IsNull() && !plan.OptimizeIoTConnectivity.IsUnknown() {
+		state.OptimizeIoTConnectivity = plan.OptimizeIoTConnectivity
+	}
 }
 
 func (r *wlanResource) modelToAPI(m *wlanResourceModel) *unifi.WLAN {
@@ -457,6 +485,20 @@ func (r *wlanResource) modelToAPI(m *wlanResourceModel) *unifi.WLAN {
 		wlan.WPA3Transition = m.WPA3Transition.ValueBool()
 	}
 
+	// Application is mutually exclusive: standard (default), hotspot (is_guest),
+	// or iot (enhanced_iot). Always set both flags so switching between values
+	// clears the previous one on the controller.
+	app := "standard"
+	if !m.Application.IsNull() && !m.Application.IsUnknown() {
+		app = m.Application.ValueString()
+	}
+	wlan.IsGuest = app == "hotspot"
+	wlan.EnhancedIot = app == "iot"
+
+	if !m.OptimizeIoTConnectivity.IsNull() {
+		wlan.OptimizeIotWifiConnectivity = m.OptimizeIoTConnectivity.ValueBool()
+	}
+
 	return wlan
 }
 
@@ -494,4 +536,15 @@ func (r *wlanResource) apiToModel(wlan *unifi.WLAN, m *wlanResourceModel, site s
 
 	m.WPA3Support = types.BoolValue(wlan.WPA3Support)
 	m.WPA3Transition = types.BoolValue(wlan.WPA3Transition)
+
+	switch {
+	case wlan.IsGuest:
+		m.Application = types.StringValue("hotspot")
+	case wlan.EnhancedIot:
+		m.Application = types.StringValue("iot")
+	default:
+		m.Application = types.StringValue("standard")
+	}
+
+	m.OptimizeIoTConnectivity = types.BoolValue(wlan.OptimizeIotWifiConnectivity)
 }

--- a/internal/provider/wlan_resource_test.go
+++ b/internal/provider/wlan_resource_test.go
@@ -1177,12 +1177,16 @@ func TestAccWLAN_applicationTransitions(t *testing.T) {
 	netName := fmt.Sprintf("tfacc-wlan-net-%s", suffix)
 	wlanName := fmt.Sprintf("tfacc-wlan-%s", suffix)
 
+	// wifi_band is pinned to 2g because the controller coerces iot WLANs to 2g
+	// on updates, which would cause an inconsistent-plan error if we let the
+	// default ("both") ride through each step.
 	config := func(app string) string {
 		return wlanTestNetwork(netName, vlan) + fmt.Sprintf(`
 resource "terrifi_wlan" "test" {
   name        = %q
   passphrase  = "testpassword123"
   network_id  = terrifi_network.wlan_test.id
+  wifi_band   = "2g"
   application = %q
 }
 `, wlanName, app)
@@ -1223,12 +1227,16 @@ func TestAccWLAN_optimizeIoTConnectivity(t *testing.T) {
 	netName := fmt.Sprintf("tfacc-wlan-net-%s", suffix)
 	wlanName := fmt.Sprintf("tfacc-wlan-%s", suffix)
 
+	// wifi_band is pinned to 2g because the controller coerces iot WLANs with
+	// optimize_iot_connectivity to 2g, which would cause an inconsistent-plan
+	// error if we left wifi_band defaulted to "both".
 	config := func(optimize bool) string {
 		return wlanTestNetwork(netName, vlan) + fmt.Sprintf(`
 resource "terrifi_wlan" "test" {
   name                      = %q
   passphrase                = "testpassword123"
   network_id                = terrifi_network.wlan_test.id
+  wifi_band                 = "2g"
   application               = "iot"
   optimize_iot_connectivity = %t
 }

--- a/internal/provider/wlan_resource_test.go
+++ b/internal/provider/wlan_resource_test.go
@@ -125,6 +125,83 @@ func TestWLANModelToAPI(t *testing.T) {
 		assert.True(t, wlan.WPA3Support)
 		assert.True(t, wlan.WPA3Transition)
 	})
+
+	t.Run("application standard (default)", func(t *testing.T) {
+		model := &wlanResourceModel{
+			Name:      types.StringValue("Std"),
+			NetworkID: types.StringValue("n"),
+		}
+
+		wlan := r.modelToAPI(model)
+
+		assert.False(t, wlan.IsGuest)
+		assert.False(t, wlan.EnhancedIot)
+	})
+
+	t.Run("application hotspot sets is_guest", func(t *testing.T) {
+		model := &wlanResourceModel{
+			Name:        types.StringValue("HS"),
+			NetworkID:   types.StringValue("n"),
+			Application: types.StringValue("hotspot"),
+		}
+
+		wlan := r.modelToAPI(model)
+
+		assert.True(t, wlan.IsGuest)
+		assert.False(t, wlan.EnhancedIot)
+	})
+
+	t.Run("application iot sets enhanced_iot", func(t *testing.T) {
+		model := &wlanResourceModel{
+			Name:        types.StringValue("IoT"),
+			NetworkID:   types.StringValue("n"),
+			Application: types.StringValue("iot"),
+		}
+
+		wlan := r.modelToAPI(model)
+
+		assert.False(t, wlan.IsGuest)
+		assert.True(t, wlan.EnhancedIot)
+	})
+
+	t.Run("application standard explicitly clears both flags", func(t *testing.T) {
+		model := &wlanResourceModel{
+			Name:        types.StringValue("Std"),
+			NetworkID:   types.StringValue("n"),
+			Application: types.StringValue("standard"),
+		}
+
+		wlan := r.modelToAPI(model)
+
+		assert.False(t, wlan.IsGuest)
+		assert.False(t, wlan.EnhancedIot)
+	})
+
+	t.Run("optimize_iot_connectivity true", func(t *testing.T) {
+		model := &wlanResourceModel{
+			Name:                    types.StringValue("IoT"),
+			NetworkID:               types.StringValue("n"),
+			Application:             types.StringValue("iot"),
+			OptimizeIoTConnectivity: types.BoolValue(true),
+		}
+
+		wlan := r.modelToAPI(model)
+
+		assert.True(t, wlan.OptimizeIotWifiConnectivity)
+	})
+
+	t.Run("optimize_iot_connectivity false", func(t *testing.T) {
+		model := &wlanResourceModel{
+			Name:                    types.StringValue("IoT"),
+			NetworkID:               types.StringValue("n"),
+			Application:             types.StringValue("iot"),
+			OptimizeIoTConnectivity: types.BoolValue(false),
+		}
+
+		wlan := r.modelToAPI(model)
+
+		assert.False(t, wlan.OptimizeIotWifiConnectivity)
+	})
 }
 
 func TestWLANAPIToModel(t *testing.T) {
@@ -232,6 +309,48 @@ func TestWLANAPIToModel(t *testing.T) {
 		assert.Equal(t, "wpa2", model.WPAMode.ValueString())
 	})
 
+	t.Run("optimize_iot_connectivity round-trips", func(t *testing.T) {
+		for _, v := range []bool{true, false} {
+			wlan := &unifi.WLAN{
+				ID:                          "id",
+				Name:                        "n",
+				NetworkID:                   "net",
+				OptimizeIotWifiConnectivity: v,
+			}
+			var model wlanResourceModel
+			r.apiToModel(wlan, &model, "default")
+			assert.Equal(t, v, model.OptimizeIoTConnectivity.ValueBool())
+		}
+	})
+
+	t.Run("application derived from flags", func(t *testing.T) {
+		cases := []struct {
+			name        string
+			isGuest     bool
+			enhancedIot bool
+			want        string
+		}{
+			{"neither -> standard", false, false, "standard"},
+			{"is_guest -> hotspot", true, false, "hotspot"},
+			{"enhanced_iot -> iot", false, true, "iot"},
+			{"is_guest takes precedence over enhanced_iot", true, true, "hotspot"},
+		}
+		for _, tc := range cases {
+			t.Run(tc.name, func(t *testing.T) {
+				wlan := &unifi.WLAN{
+					ID:          "id",
+					Name:        "n",
+					NetworkID:   "net",
+					IsGuest:     tc.isGuest,
+					EnhancedIot: tc.enhancedIot,
+				}
+				var model wlanResourceModel
+				r.apiToModel(wlan, &model, "default")
+				assert.Equal(t, tc.want, model.Application.ValueString())
+			})
+		}
+	})
+
 	t.Run("passphrase from API is ignored", func(t *testing.T) {
 		wlan := &unifi.WLAN{
 			ID:          "wlan-pass",
@@ -290,6 +409,32 @@ func TestWLANApplyPlanToState(t *testing.T) {
 		assert.True(t, state.Passphrase.IsNull())
 		assert.Equal(t, "net123", state.NetworkID.ValueString())
 		assert.Equal(t, "both", state.WifiBand.ValueString())
+	})
+
+	t.Run("application update propagates to state", func(t *testing.T) {
+		state := &wlanResourceModel{
+			Application: types.StringValue("standard"),
+		}
+		plan := &wlanResourceModel{
+			Application: types.StringValue("iot"),
+		}
+
+		r.applyPlanToState(plan, state)
+
+		assert.Equal(t, "iot", state.Application.ValueString())
+	})
+
+	t.Run("optimize_iot_connectivity update propagates", func(t *testing.T) {
+		state := &wlanResourceModel{
+			OptimizeIoTConnectivity: types.BoolValue(false),
+		}
+		plan := &wlanResourceModel{
+			OptimizeIoTConnectivity: types.BoolValue(true),
+		}
+
+		r.applyPlanToState(plan, state)
+
+		assert.True(t, state.OptimizeIoTConnectivity.ValueBool())
 	})
 }
 
@@ -943,6 +1088,208 @@ resource "terrifi_wlan" "test" {
 }
 `, wlanName),
 				Check: resource.TestCheckResourceAttr("terrifi_wlan.test", "wpa_mode", "wpa2"),
+			},
+		},
+	})
+}
+
+func TestAccWLAN_applicationDefault(t *testing.T) {
+	requireHardware(t)
+	suffix := randomSuffix()
+	vlan := randomVLAN()
+	netName := fmt.Sprintf("tfacc-wlan-net-%s", suffix)
+	wlanName := fmt.Sprintf("tfacc-wlan-%s", suffix)
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:                 func() { preCheck(t) },
+		ProtoV6ProviderFactories: testAccProtoV6ProviderFactories,
+		Steps: []resource.TestStep{
+			{
+				Config: wlanTestNetwork(netName, vlan) + fmt.Sprintf(`
+resource "terrifi_wlan" "test" {
+  name       = %q
+  passphrase = "testpassword123"
+  network_id = terrifi_network.wlan_test.id
+}
+`, wlanName),
+				Check: resource.TestCheckResourceAttr("terrifi_wlan.test", "application", "standard"),
+			},
+		},
+	})
+}
+
+func TestAccWLAN_applicationHotspot(t *testing.T) {
+	requireHardware(t)
+	suffix := randomSuffix()
+	vlan := randomVLAN()
+	netName := fmt.Sprintf("tfacc-wlan-net-%s", suffix)
+	wlanName := fmt.Sprintf("tfacc-wlan-%s", suffix)
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:                 func() { preCheck(t) },
+		ProtoV6ProviderFactories: testAccProtoV6ProviderFactories,
+		Steps: []resource.TestStep{
+			{
+				Config: wlanTestNetwork(netName, vlan) + fmt.Sprintf(`
+resource "terrifi_wlan" "test" {
+  name        = %q
+  passphrase  = "testpassword123"
+  network_id  = terrifi_network.wlan_test.id
+  application = "hotspot"
+}
+`, wlanName),
+				Check: resource.TestCheckResourceAttr("terrifi_wlan.test", "application", "hotspot"),
+			},
+		},
+	})
+}
+
+func TestAccWLAN_applicationIot(t *testing.T) {
+	requireHardware(t)
+	suffix := randomSuffix()
+	vlan := randomVLAN()
+	netName := fmt.Sprintf("tfacc-wlan-net-%s", suffix)
+	wlanName := fmt.Sprintf("tfacc-wlan-%s", suffix)
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:                 func() { preCheck(t) },
+		ProtoV6ProviderFactories: testAccProtoV6ProviderFactories,
+		Steps: []resource.TestStep{
+			{
+				Config: wlanTestNetwork(netName, vlan) + fmt.Sprintf(`
+resource "terrifi_wlan" "test" {
+  name        = %q
+  passphrase  = "testpassword123"
+  network_id  = terrifi_network.wlan_test.id
+  application = "iot"
+}
+`, wlanName),
+				Check: resource.TestCheckResourceAttr("terrifi_wlan.test", "application", "iot"),
+			},
+		},
+	})
+}
+
+func TestAccWLAN_applicationTransitions(t *testing.T) {
+	requireHardware(t)
+	suffix := randomSuffix()
+	vlan := randomVLAN()
+	netName := fmt.Sprintf("tfacc-wlan-net-%s", suffix)
+	wlanName := fmt.Sprintf("tfacc-wlan-%s", suffix)
+
+	config := func(app string) string {
+		return wlanTestNetwork(netName, vlan) + fmt.Sprintf(`
+resource "terrifi_wlan" "test" {
+  name        = %q
+  passphrase  = "testpassword123"
+  network_id  = terrifi_network.wlan_test.id
+  application = %q
+}
+`, wlanName, app)
+	}
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:                 func() { preCheck(t) },
+		ProtoV6ProviderFactories: testAccProtoV6ProviderFactories,
+		Steps: []resource.TestStep{
+			{
+				Config: config("standard"),
+				Check:  resource.TestCheckResourceAttr("terrifi_wlan.test", "application", "standard"),
+			},
+			{
+				Config: config("hotspot"),
+				Check:  resource.TestCheckResourceAttr("terrifi_wlan.test", "application", "hotspot"),
+			},
+			{
+				Config: config("iot"),
+				Check:  resource.TestCheckResourceAttr("terrifi_wlan.test", "application", "iot"),
+			},
+			{
+				Config: config("hotspot"),
+				Check:  resource.TestCheckResourceAttr("terrifi_wlan.test", "application", "hotspot"),
+			},
+			{
+				Config: config("standard"),
+				Check:  resource.TestCheckResourceAttr("terrifi_wlan.test", "application", "standard"),
+			},
+		},
+	})
+}
+
+func TestAccWLAN_optimizeIoTConnectivity(t *testing.T) {
+	requireHardware(t)
+	suffix := randomSuffix()
+	vlan := randomVLAN()
+	netName := fmt.Sprintf("tfacc-wlan-net-%s", suffix)
+	wlanName := fmt.Sprintf("tfacc-wlan-%s", suffix)
+
+	config := func(optimize bool) string {
+		return wlanTestNetwork(netName, vlan) + fmt.Sprintf(`
+resource "terrifi_wlan" "test" {
+  name                      = %q
+  passphrase                = "testpassword123"
+  network_id                = terrifi_network.wlan_test.id
+  application               = "iot"
+  optimize_iot_connectivity = %t
+}
+`, wlanName, optimize)
+	}
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:                 func() { preCheck(t) },
+		ProtoV6ProviderFactories: testAccProtoV6ProviderFactories,
+		Steps: []resource.TestStep{
+			{
+				Config: config(true),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr("terrifi_wlan.test", "application", "iot"),
+					resource.TestCheckResourceAttr("terrifi_wlan.test", "optimize_iot_connectivity", "true"),
+				),
+			},
+			{
+				Config: config(false),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr("terrifi_wlan.test", "optimize_iot_connectivity", "false"),
+				),
+			},
+			{
+				Config: config(true),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr("terrifi_wlan.test", "optimize_iot_connectivity", "true"),
+				),
+			},
+		},
+	})
+}
+
+func TestAccWLAN_applicationIdempotent(t *testing.T) {
+	requireHardware(t)
+	suffix := randomSuffix()
+	vlan := randomVLAN()
+	netName := fmt.Sprintf("tfacc-wlan-net-%s", suffix)
+	wlanName := fmt.Sprintf("tfacc-wlan-%s", suffix)
+
+	config := wlanTestNetwork(netName, vlan) + fmt.Sprintf(`
+resource "terrifi_wlan" "test" {
+  name        = %q
+  passphrase  = "testpassword123"
+  network_id  = terrifi_network.wlan_test.id
+  application = "iot"
+}
+`, wlanName)
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:                 func() { preCheck(t) },
+		ProtoV6ProviderFactories: testAccProtoV6ProviderFactories,
+		Steps: []resource.TestStep{
+			{
+				Config: config,
+				Check:  resource.TestCheckResourceAttr("terrifi_wlan.test", "application", "iot"),
+			},
+			{
+				Config:             config,
+				PlanOnly:           true,
+				ExpectNonEmptyPlan: false,
 			},
 		},
 	})


### PR DESCRIPTION
## Summary
- Adds `application` attribute to `terrifi_wlan` with values `standard` / `hotspot` / `iot`, backed by the mutually-exclusive `is_guest` and `enhanced_iot` flags in the UniFi API.
- Adds `optimize_iot_connectivity` boolean attribute, backed by `optimize_iot_wifi_connectivity`.
- Import-block generator emits both attributes; docs updated.

Part of #141.

## Test plan
- [x] Unit tests pass (`go test ./...`)
- [x] Acceptance tests against hardware:
  - [x] `TestAccWLAN_applicationDefault`
  - [x] `TestAccWLAN_applicationHotspot`
  - [x] `TestAccWLAN_applicationIot`
  - [x] `TestAccWLAN_applicationTransitions`
  - [x] `TestAccWLAN_applicationIdempotent`
  - [ ] `TestAccWLAN_optimizeIoTConnectivity`

🤖 Generated with [Claude Code](https://claude.com/claude-code)