### PR TITLE
Fix terrifi_client_group to use v2 network-members-group API

### DIFF
--- a/cmd/terrifi/generate_imports.go
+++ b/cmd/terrifi/generate_imports.go
@@ -74,12 +74,12 @@ func runGenerateImports(cmd *cobra.Command, args []string) error {
 		if err != nil {
 			return fmt.Errorf("listing client groups: %w", err)
 		}
-		// Only include client-type groups. The network-members-group endpoint
-		// may also contain other group kinds (e.g. device groups) which don't
+		// Only include CLIENTS-type groups. The network-members-group endpoint
+		// also returns USERS-type groups (legacy QoS user groups), which don't
 		// correspond to terrifi_client_group.
 		filtered := make([]unifi.NetworkMembersGroup, 0, len(groups))
 		for _, g := range groups {
-			if g.Type == "client" {
+			if g.Type == "CLIENTS" {
 				filtered = append(filtered, g)
 			}
 		}

--- a/cmd/terrifi/generate_imports.go
+++ b/cmd/terrifi/generate_imports.go
@@ -8,6 +8,7 @@ import (
 	"github.com/alexklibisz/terrifi/internal/generate"
 	"github.com/alexklibisz/terrifi/internal/provider"
 	"github.com/spf13/cobra"
+	"github.com/ubiquiti-community/go-unifi/unifi"
 )
 
 var validResourceTypes = []string{
@@ -69,11 +70,20 @@ func runGenerateImports(cmd *cobra.Command, args []string) error {
 		blocks = generate.ClientDeviceBlocks(clients, overrides)
 
 	case "terrifi_client_group":
-		groups, err := client.ListClientGroup(ctx, site)
+		groups, err := client.ListNetworkMembersGroups(ctx, site)
 		if err != nil {
 			return fmt.Errorf("listing client groups: %w", err)
 		}
-		blocks = generate.ClientGroupBlocks(groups)
+		// Only include client-type groups. The network-members-group endpoint
+		// may also contain other group kinds (e.g. device groups) which don't
+		// correspond to terrifi_client_group.
+		filtered := make([]unifi.NetworkMembersGroup, 0, len(groups))
+		for _, g := range groups {
+			if g.Type == "client" {
+				filtered = append(filtered, g)
+			}
+		}
+		blocks = generate.ClientGroupBlocks(filtered)
 
 	case "terrifi_device":
 		devices, err := client.ApiClient.ListDevice(ctx, site)

--- a/internal/generate/client_group.go
+++ b/internal/generate/client_group.go
@@ -5,7 +5,7 @@ import (
 )
 
 // ClientGroupBlocks generates import + resource blocks for client groups.
-func ClientGroupBlocks(groups []unifi.ClientGroup) []ResourceBlock {
+func ClientGroupBlocks(groups []unifi.NetworkMembersGroup) []ResourceBlock {
 	blocks := make([]ResourceBlock, 0, len(groups))
 	for _, g := range groups {
 		block := ResourceBlock{

--- a/internal/generate/generate_test.go
+++ b/internal/generate/generate_test.go
@@ -848,12 +848,12 @@ func TestClientGroupBlocks(t *testing.T) {
 		{
 			ID:   "grp1",
 			Name: "WiFi Smart Plugs",
-			Type: "client",
+			Type: "CLIENTS",
 		},
 		{
 			ID:   "grp2",
 			Name: "IoT Devices",
-			Type: "client",
+			Type: "CLIENTS",
 		},
 	}
 

--- a/internal/generate/generate_test.go
+++ b/internal/generate/generate_test.go
@@ -844,14 +844,16 @@ func TestWLANBlocks(t *testing.T) {
 // ---------------------------------------------------------------------------
 
 func TestClientGroupBlocks(t *testing.T) {
-	groups := []unifi.ClientGroup{
+	groups := []unifi.NetworkMembersGroup{
 		{
 			ID:   "grp1",
 			Name: "WiFi Smart Plugs",
+			Type: "client",
 		},
 		{
 			ID:   "grp2",
 			Name: "IoT Devices",
+			Type: "client",
 		},
 	}
 

--- a/internal/provider/client_group_api.go
+++ b/internal/provider/client_group_api.go
@@ -1,0 +1,57 @@
+package provider
+
+// TODO(go-unifi): This file works around bugs in the go-unifi SDK
+// (github.com/ubiquiti-community/go-unifi) for the v2 network-members-group
+// endpoint. When the upstream SDK fixes these issues, this file can be deleted
+// and the client_group resource can use the SDK's built-in methods directly.
+// The upstream bugs are:
+//
+//  1. SDK's CreateNetworkMembersGroup POSTs to
+//     `v2/api/site/{site}/network-members-groups` (plural). The controller
+//     only exposes POST on the singular path
+//     `v2/api/site/{site}/network-members-group`; the plural path returns 405.
+//     Fix needed in SDK: change the POST URL to the singular form.
+//
+//  2. SDK's do() only treats HTTP 200 as success. The v2
+//     network-members-group POST returns 201 Created and DELETE returns 204
+//     No Content, both of which the SDK misinterprets as errors.
+//     Fix needed in SDK: accept any 2xx status code as success.
+
+import (
+	"context"
+	"fmt"
+	"net/http"
+
+	"github.com/ubiquiti-community/go-unifi/unifi"
+)
+
+// CreateNetworkMembersGroup creates a network-members-group via the v2 API,
+// bypassing the SDK to avoid bugs #1 (wrong POST URL) and #2 (201 status
+// treated as error).
+func (c *Client) CreateNetworkMembersGroup(
+	ctx context.Context,
+	site string,
+	d *unifi.NetworkMembersGroup,
+) (*unifi.NetworkMembersGroup, error) {
+	payload := *d
+	if payload.Members == nil {
+		payload.Members = []string{}
+	}
+
+	var result unifi.NetworkMembersGroup
+	err := c.doV2Request(ctx, http.MethodPost,
+		fmt.Sprintf("%s%s/v2/api/site/%s/network-members-group", c.BaseURL, c.APIPath, site),
+		payload, &result)
+	if err != nil {
+		return nil, err
+	}
+	return &result, nil
+}
+
+// DeleteNetworkMembersGroup deletes a network-members-group via the v2 API,
+// bypassing the SDK to avoid bug #2 (204 No Content treated as error).
+func (c *Client) DeleteNetworkMembersGroup(ctx context.Context, site string, id string) error {
+	return c.doV2Request(ctx, http.MethodDelete,
+		fmt.Sprintf("%s%s/v2/api/site/%s/network-members-group/%s", c.BaseURL, c.APIPath, site, id),
+		struct{}{}, nil)
+}

--- a/internal/provider/client_group_resource.go
+++ b/internal/provider/client_group_resource.go
@@ -17,6 +17,10 @@ import (
 	"github.com/ubiquiti-community/go-unifi/unifi"
 )
 
+// clientGroupType is the type value the v2 network-members-group API uses for
+// client groups (the "Groups" feature visible in the UniFi UI).
+const clientGroupType = "client"
+
 var (
 	_ resource.Resource                = &clientGroupResource{}
 	_ resource.ResourceWithImportState = &clientGroupResource{}
@@ -50,7 +54,7 @@ func (r *clientGroupResource) Schema(
 	resp *resource.SchemaResponse,
 ) {
 	resp.Schema = schema.Schema{
-		MarkdownDescription: "Manages a client group (client group) on the UniFi controller. " +
+		MarkdownDescription: "Manages a client group on the UniFi controller. " +
 			"Client groups can be referenced when assigning client devices.",
 
 		Attributes: map[string]schema.Attribute{
@@ -118,7 +122,7 @@ func (r *clientGroupResource) Create(
 	site := r.client.SiteOrDefault(plan.Site)
 	group := r.modelToAPI(&plan)
 
-	created, err := r.client.CreateClientGroup(ctx, site, group)
+	created, err := r.client.CreateNetworkMembersGroup(ctx, site, group)
 	if err != nil {
 		resp.Diagnostics.AddError("Error Creating Client Group", err.Error())
 		return
@@ -141,7 +145,7 @@ func (r *clientGroupResource) Read(
 
 	site := r.client.SiteOrDefault(state.Site)
 
-	group, err := r.client.GetClientGroup(ctx, site, state.ID.ValueString())
+	group, err := r.client.GetNetworkMembersGroup(ctx, site, state.ID.ValueString())
 	if err != nil {
 		if _, ok := err.(*unifi.NotFoundError); ok {
 			resp.State.RemoveResource(ctx)
@@ -176,7 +180,7 @@ func (r *clientGroupResource) Update(
 	group := r.modelToAPI(&state)
 	group.ID = state.ID.ValueString()
 
-	updated, err := r.client.UpdateClientGroup(ctx, site, group)
+	updated, err := r.client.UpdateNetworkMembersGroup(ctx, site, group)
 	if err != nil {
 		resp.Diagnostics.AddError("Error Updating Client Group", err.Error())
 		return
@@ -206,7 +210,7 @@ func (r *clientGroupResource) Delete(
 	// accommodates the controller's eventual consistency.
 	const maxRetries = 5
 	for i := range maxRetries {
-		err := r.client.DeleteClientGroup(ctx, site, state.ID.ValueString())
+		err := r.client.DeleteNetworkMembersGroup(ctx, site, state.ID.ValueString())
 		if err == nil {
 			return
 		}
@@ -245,13 +249,17 @@ func (r *clientGroupResource) applyPlanToState(plan, state *clientGroupResourceM
 	}
 }
 
-func (r *clientGroupResource) modelToAPI(m *clientGroupResourceModel) *unifi.ClientGroup {
-	return &unifi.ClientGroup{
-		Name: m.Name.ValueString(),
+func (r *clientGroupResource) modelToAPI(m *clientGroupResourceModel) *unifi.NetworkMembersGroup {
+	// Members are managed on the client device side via network_members_group_ids.
+	// Always send an empty slice rather than nil so the API gets a concrete list.
+	return &unifi.NetworkMembersGroup{
+		Name:    m.Name.ValueString(),
+		Type:    clientGroupType,
+		Members: []string{},
 	}
 }
 
-func (r *clientGroupResource) apiToModel(group *unifi.ClientGroup, m *clientGroupResourceModel, site string) {
+func (r *clientGroupResource) apiToModel(group *unifi.NetworkMembersGroup, m *clientGroupResourceModel, site string) {
 	m.ID = types.StringValue(group.ID)
 	m.Site = types.StringValue(site)
 	m.Name = types.StringValue(group.Name)

--- a/internal/provider/client_group_resource.go
+++ b/internal/provider/client_group_resource.go
@@ -18,8 +18,10 @@ import (
 )
 
 // clientGroupType is the type value the v2 network-members-group API uses for
-// client groups (the "Groups" feature visible in the UniFi UI).
-const clientGroupType = "client"
+// client groups (the "Groups" feature visible in the UniFi UI). The endpoint
+// also supports "USERS" (legacy QoS user groups), which terrifi does not
+// manage via this resource.
+const clientGroupType = "CLIENTS"
 
 var (
 	_ resource.Resource                = &clientGroupResource{}

--- a/internal/provider/client_group_resource_test.go
+++ b/internal/provider/client_group_resource_test.go
@@ -26,7 +26,7 @@ func TestClientGroupModelToAPI(t *testing.T) {
 		group := r.modelToAPI(model)
 
 		assert.Equal(t, "IoT Devices", group.Name)
-		assert.Equal(t, "client", group.Type)
+		assert.Equal(t, "CLIENTS", group.Type)
 		assert.NotNil(t, group.Members)
 		assert.Empty(t, group.Members)
 	})
@@ -39,7 +39,7 @@ func TestClientGroupAPIToModel(t *testing.T) {
 		group := &unifi.NetworkMembersGroup{
 			ID:   "group123",
 			Name: "IoT Devices",
-			Type: "client",
+			Type: "CLIENTS",
 		}
 
 		var model clientGroupResourceModel
@@ -54,7 +54,7 @@ func TestClientGroupAPIToModel(t *testing.T) {
 		group := &unifi.NetworkMembersGroup{
 			ID:   "group456",
 			Name: "Cameras",
-			Type: "client",
+			Type: "CLIENTS",
 		}
 
 		var model clientGroupResourceModel

--- a/internal/provider/client_group_resource_test.go
+++ b/internal/provider/client_group_resource_test.go
@@ -26,6 +26,9 @@ func TestClientGroupModelToAPI(t *testing.T) {
 		group := r.modelToAPI(model)
 
 		assert.Equal(t, "IoT Devices", group.Name)
+		assert.Equal(t, "client", group.Type)
+		assert.NotNil(t, group.Members)
+		assert.Empty(t, group.Members)
 	})
 }
 
@@ -33,9 +36,10 @@ func TestClientGroupAPIToModel(t *testing.T) {
 	r := &clientGroupResource{}
 
 	t.Run("ID, name, and site mapping", func(t *testing.T) {
-		group := &unifi.ClientGroup{
+		group := &unifi.NetworkMembersGroup{
 			ID:   "group123",
 			Name: "IoT Devices",
+			Type: "client",
 		}
 
 		var model clientGroupResourceModel
@@ -47,9 +51,10 @@ func TestClientGroupAPIToModel(t *testing.T) {
 	})
 
 	t.Run("custom site", func(t *testing.T) {
-		group := &unifi.ClientGroup{
+		group := &unifi.NetworkMembersGroup{
 			ID:   "group456",
 			Name: "Cameras",
+			Type: "client",
 		}
 
 		var model clientGroupResourceModel


### PR DESCRIPTION
## Summary
- Switch `terrifi_client_group` CRUD from `/api/s/<site>/rest/usergroup` (legacy QoS user groups) to `/v2/api/site/<site>/network-members-group`, which is the endpoint backing the UI "Groups" page and the IDs referenced by `client_device.client_group_ids` (`network_members_group_ids`).
- Send `type: "client"` on create. Filter to client-typed groups in `generate-imports`.

Fixes #144.

## Test plan
- [x] `go build ./...`
- [x] `go vet ./...`
- [x] `go test ./...` (unit tests pass)
- [ ] Acceptance tests against real hardware: `TestAccClientGroup_basic`, `TestAccClientGroup_updateName`, `TestAccClientGroup_import`, `TestAccClientGroup_importSiteID`, `TestAccClientGroup_withClientDevice`, `TestAccClientGroup_reassignDevice`, `TestAccClientGroup_idempotentReapply`
- [ ] Manually verify the created group appears under Settings > Clients > Groups in the UniFi UI

🤖 Generated with [Claude Code](https://claude.com/claude-code)