### PR TITLE
Fix terrifi_device read failing on numeric tx_power (#147)

### DIFF
--- a/cmd/terrifi/generate_imports.go
+++ b/cmd/terrifi/generate_imports.go
@@ -76,7 +76,7 @@ func runGenerateImports(cmd *cobra.Command, args []string) error {
 		blocks = generate.ClientGroupBlocks(groups)
 
 	case "terrifi_device":
-		devices, err := client.ApiClient.ListDevice(ctx, site)
+		devices, err := client.ListDevice(ctx, site)
 		if err != nil {
 			return fmt.Errorf("listing devices: %w", err)
 		}

--- a/internal/provider/device_api.go
+++ b/internal/provider/device_api.go
@@ -1,24 +1,39 @@
 package provider
 
-// TODO(go-unifi): This file is a workaround for the SDK's UpdateDevice method.
-// The SDK's UpdateDevice (1) re-fetches the device by MAC internally, (2) diffs
-// against the target using JSON marshal/unmarshal, and (3) sends only changed
-// fields. When the re-fetched device differs from the target in unexpected ways
-// (e.g., stat counters that changed between reads, or structural differences
-// between list vs. single-device endpoints), the diff includes noise that
-// confuses the controller, causing it to return empty results (our "not found:
-// type=" error).
+// TODO(go-unifi): This file contains two workarounds for go-unifi SDK bugs
+// affecting device CRUD.
 //
-// This workaround sends a minimal PUT payload containing only the fields we
-// actually manage, avoiding the fragile diff mechanism entirely.
-//
+// 1. UpdateDevice diff mechanism. The SDK's UpdateDevice (1) re-fetches the
+// device by MAC internally, (2) diffs against the target using JSON
+// marshal/unmarshal, and (3) sends only changed fields. When the re-fetched
+// device differs from the target in unexpected ways (e.g., stat counters that
+// changed between reads, or structural differences between list vs.
+// single-device endpoints), the diff includes noise that confuses the
+// controller, causing it to return empty results (our "not found: type="
+// error). This workaround sends a minimal PUT payload containing only the
+// fields we actually manage, avoiding the fragile diff mechanism entirely.
 // Fix needed in SDK: UpdateDevice's diff approach should be more robust, or
 // provide a way to do a simple field-level PUT without the diff.
+//
+// 2. DeviceRadioTable.TxPower unmarshal. The SDK declares TxPower as a Go
+// string with json tag `tx_power`, but the controller emits a JSON number for
+// some devices (e.g. an integer dBm value), so the SDK's UnmarshalJSON for
+// DeviceRadioTable fails with: "unable to unmarshal alias: json: cannot
+// unmarshal number into Go struct field .Alias.tx_power of type string". This
+// blocks every Read on affected sites. We bypass GetDevice/GetDeviceByMAC/
+// ListDevice in the SDK and call the v1 stat/device endpoints ourselves,
+// pre-processing the raw JSON to wrap numeric tx_power values in quotes
+// before unmarshaling into unifi.Device.
+// Fix needed in SDK: TxPower should accept either a string or a number on
+// the wire (e.g. via a custom UnmarshalJSON that uses json.Number).
 
 import (
 	"context"
+	"encoding/json"
 	"fmt"
 	"net/http"
+	"regexp"
+	"strings"
 
 	"github.com/ubiquiti-community/go-unifi/unifi"
 )
@@ -151,7 +166,7 @@ func (c *Client) UpdateDevice(ctx context.Context, site string, id string, m *de
 	if len(plannedByRadio) > 0 {
 		// Read-modify-write: fetch current device to preserve non-managed radio
 		// fields and entries for radios not mentioned in the plan.
-		existing, err := c.ApiClient.GetDevice(ctx, site, id)
+		existing, err := c.GetDevice(ctx, site, id)
 		if err != nil {
 			return fmt.Errorf("reading device for radio settings merge: %w", err)
 		}
@@ -186,4 +201,98 @@ func (c *Client) UpdateDevice(ctx context.Context, site string, id string, m *de
 	}
 
 	return nil
+}
+
+// txPowerNumberRE matches a JSON `"tx_power": <number>` pair so we can wrap the
+// number in quotes before handing the bytes to the SDK's UnmarshalJSON, which
+// only accepts a string. The controller emits the field as a number for some
+// devices (notably APs reporting dBm as an integer).
+var txPowerNumberRE = regexp.MustCompile(`"tx_power"\s*:\s*(-?\d+(?:\.\d+)?)`)
+
+// fixTxPowerBytes coerces JSON numeric tx_power values into strings so the SDK's
+// DeviceRadioTable.UnmarshalJSON does not fail. See the file-level TODO for
+// details.
+func fixTxPowerBytes(b []byte) []byte {
+	return txPowerNumberRE.ReplaceAll(b, []byte(`"tx_power":"$1"`))
+}
+
+// deviceListResponse is the v1 stat/device envelope. We unmarshal into
+// json.RawMessage first so we can patch the bytes before decoding into
+// unifi.Device.
+type deviceListResponse struct {
+	Meta struct {
+		RC  string `json:"rc"`
+		Msg string `json:"msg,omitempty"`
+	} `json:"meta"`
+	Data []json.RawMessage `json:"data"`
+}
+
+// fetchDeviceList performs a GET against the v1 stat/device endpoint, applies
+// the tx_power coercion, and decodes each entry into unifi.Device.
+func (c *Client) fetchDeviceList(ctx context.Context, site, suffix string) ([]unifi.Device, error) {
+	url := fmt.Sprintf("%s%s/api/s/%s/stat/device", c.BaseURL, c.APIPath, site)
+	if suffix != "" {
+		url += "/" + suffix
+	}
+
+	var raw json.RawMessage
+	if err := c.doV2Request(ctx, http.MethodGet, url, nil, &raw); err != nil {
+		return nil, err
+	}
+
+	var envelope deviceListResponse
+	if err := json.Unmarshal(fixTxPowerBytes(raw), &envelope); err != nil {
+		return nil, fmt.Errorf("decoding device envelope: %w", err)
+	}
+
+	if envelope.Meta.RC != "" && envelope.Meta.RC != "ok" {
+		return nil, fmt.Errorf("controller returned rc=%s msg=%s", envelope.Meta.RC, envelope.Meta.Msg)
+	}
+
+	devices := make([]unifi.Device, 0, len(envelope.Data))
+	for i, item := range envelope.Data {
+		var d unifi.Device
+		if err := json.Unmarshal(item, &d); err != nil {
+			return nil, fmt.Errorf("decoding device[%d]: %w", i, err)
+		}
+		devices = append(devices, d)
+	}
+	return devices, nil
+}
+
+// ListDevice returns all devices for a site, working around the SDK's
+// tx_power unmarshal bug.
+func (c *Client) ListDevice(ctx context.Context, site string) ([]unifi.Device, error) {
+	return c.fetchDeviceList(ctx, site, "")
+}
+
+// GetDeviceByMAC fetches a device by MAC, working around the SDK's tx_power
+// unmarshal bug. The controller's stat/device/<mac> endpoint returns a single
+// device when a MAC is supplied.
+func (c *Client) GetDeviceByMAC(ctx context.Context, site, mac string) (*unifi.Device, error) {
+	devices, err := c.fetchDeviceList(ctx, site, strings.ToLower(mac))
+	if err != nil {
+		return nil, err
+	}
+	if len(devices) == 0 {
+		return nil, &unifi.NotFoundError{}
+	}
+	d := devices[0]
+	return &d, nil
+}
+
+// GetDevice fetches a device by its controller ID. The v1 stat/device endpoint
+// only supports lookup by MAC, so we list and filter, matching the SDK's
+// behavior while applying our tx_power workaround.
+func (c *Client) GetDevice(ctx context.Context, site, id string) (*unifi.Device, error) {
+	devices, err := c.ListDevice(ctx, site)
+	if err != nil {
+		return nil, err
+	}
+	for i := range devices {
+		if devices[i].ID == id {
+			return &devices[i], nil
+		}
+	}
+	return nil, &unifi.NotFoundError{}
 }

--- a/internal/provider/device_api_test.go
+++ b/internal/provider/device_api_test.go
@@ -1,0 +1,104 @@
+package provider
+
+import (
+	"encoding/json"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"github.com/ubiquiti-community/go-unifi/unifi"
+)
+
+// Verifies the workaround that wraps numeric tx_power values in quotes so the
+// SDK's DeviceRadioTable.UnmarshalJSON does not fail on payloads from
+// controllers that emit tx_power as a JSON number.
+func TestFixTxPowerBytes(t *testing.T) {
+	cases := []struct {
+		name string
+		in   string
+		want string
+	}{
+		{
+			name: "numeric tx_power gets quoted",
+			in:   `{"tx_power":23}`,
+			want: `{"tx_power":"23"}`,
+		},
+		{
+			name: "negative numeric tx_power gets quoted",
+			in:   `{"tx_power":-5}`,
+			want: `{"tx_power":"-5"}`,
+		},
+		{
+			name: "fractional tx_power gets quoted",
+			in:   `{"tx_power": 1.5}`,
+			want: `{"tx_power":"1.5"}`,
+		},
+		{
+			name: "string tx_power is left alone",
+			in:   `{"tx_power":"23"}`,
+			want: `{"tx_power":"23"}`,
+		},
+		{
+			name: "auto string is left alone",
+			in:   `{"tx_power":"auto"}`,
+			want: `{"tx_power":"auto"}`,
+		},
+		{
+			name: "tx_power_mode is not affected",
+			in:   `{"tx_power_mode":"auto","tx_power":18}`,
+			want: `{"tx_power_mode":"auto","tx_power":"18"}`,
+		},
+		{
+			name: "multiple radio entries all coerced",
+			in:   `[{"tx_power":18},{"tx_power":23}]`,
+			want: `[{"tx_power":"18"},{"tx_power":"23"}]`,
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			got := string(fixTxPowerBytes([]byte(tc.in)))
+			assert.Equal(t, tc.want, got)
+		})
+	}
+}
+
+// Verifies that a stat/device payload with a numeric tx_power decodes cleanly
+// after the workaround is applied. Without the workaround, the SDK's
+// DeviceRadioTable.UnmarshalJSON returns "cannot unmarshal number into Go
+// struct field .Alias.tx_power of type string".
+func TestFixTxPowerBytes_decodesIntoUnifiDevice(t *testing.T) {
+	const payload = `{
+		"meta": {"rc": "ok"},
+		"data": [{
+			"_id": "abc123",
+			"mac": "aa:bb:cc:dd:ee:ff",
+			"name": "AP",
+			"radio_table": [
+				{"radio": "ng", "channel": "auto", "ht": 40, "tx_power": 18, "tx_power_mode": "auto"},
+				{"radio": "na", "channel": "auto", "ht": 80, "tx_power": "23", "tx_power_mode": "high"}
+			]
+		}]
+	}`
+
+	// Sanity: raw payload fails to decode without the workaround.
+	var rawEnvelope struct {
+		Data []unifi.Device `json:"data"`
+	}
+	rawErr := json.Unmarshal([]byte(payload), &rawEnvelope)
+	require.Error(t, rawErr, "expected SDK to reject numeric tx_power without workaround")
+
+	patched := fixTxPowerBytes([]byte(payload))
+	var envelope struct {
+		Data []unifi.Device `json:"data"`
+	}
+	require.NoError(t, json.Unmarshal(patched, &envelope))
+	require.Len(t, envelope.Data, 1)
+
+	d := envelope.Data[0]
+	require.Len(t, d.RadioTable, 2)
+	assert.Equal(t, "18", d.RadioTable[0].TxPower)
+	assert.Equal(t, "auto", d.RadioTable[0].TxPowerMode)
+	assert.Equal(t, "23", d.RadioTable[1].TxPower)
+	assert.Equal(t, "high", d.RadioTable[1].TxPowerMode)
+}

--- a/internal/provider/device_data_source.go
+++ b/internal/provider/device_data_source.go
@@ -158,7 +158,7 @@ func (d *deviceDataSource) Read(
 
 	if !config.MAC.IsNull() && !config.MAC.IsUnknown() {
 		mac := strings.ToLower(config.MAC.ValueString())
-		device, err = d.client.ApiClient.GetDeviceByMAC(ctx, site, mac)
+		device, err = d.client.GetDeviceByMAC(ctx, site, mac)
 		if err != nil {
 			resp.Diagnostics.AddError(
 				"Device Not Found",
@@ -183,7 +183,7 @@ func (d *deviceDataSource) Read(
 }
 
 func (d *deviceDataSource) findDeviceByName(ctx context.Context, site, name string) (*unifi.Device, error) {
-	devices, err := d.client.ApiClient.ListDevice(ctx, site)
+	devices, err := d.client.ListDevice(ctx, site)
 	if err != nil {
 		return nil, err
 	}

--- a/internal/provider/device_resource.go
+++ b/internal/provider/device_resource.go
@@ -389,7 +389,7 @@ func (r *deviceResource) Create(
 	mac := strings.ToLower(plan.MAC.ValueString())
 
 	// Look up the existing device by MAC — it must already be adopted.
-	existing, err := r.client.ApiClient.GetDeviceByMAC(ctx, site, mac)
+	existing, err := r.client.GetDeviceByMAC(ctx, site, mac)
 	if err != nil {
 		resp.Diagnostics.AddError(
 			"Device Not Found",
@@ -408,7 +408,7 @@ func (r *deviceResource) Create(
 	}
 
 	// Re-read to get full state including runtime fields (state, ip, etc.).
-	device, err := r.client.ApiClient.GetDevice(ctx, site, existing.ID)
+	device, err := r.client.GetDevice(ctx, site, existing.ID)
 	if err != nil {
 		resp.Diagnostics.AddError("Error Reading Device After Create", err.Error())
 		return
@@ -435,7 +435,7 @@ func (r *deviceResource) Read(
 
 	site := r.client.SiteOrDefault(state.Site)
 
-	device, err := r.client.ApiClient.GetDevice(ctx, site, state.ID.ValueString())
+	device, err := r.client.GetDevice(ctx, site, state.ID.ValueString())
 	if err != nil {
 		if _, ok := err.(*unifi.NotFoundError); ok {
 			resp.State.RemoveResource(ctx)
@@ -475,7 +475,7 @@ func (r *deviceResource) Update(
 	}
 
 	// Re-read to get full state including runtime fields.
-	device, err := r.client.ApiClient.GetDevice(ctx, site, state.ID.ValueString())
+	device, err := r.client.GetDevice(ctx, site, state.ID.ValueString())
 	if err != nil {
 		resp.Diagnostics.AddError("Error Reading Device After Update", err.Error())
 		return
@@ -529,7 +529,7 @@ func (r *deviceResource) ImportState(
 		resolvedSite = r.client.SiteOrDefault(types.StringNull())
 	}
 
-	device, err := r.client.ApiClient.GetDeviceByMAC(ctx, resolvedSite, mac)
+	device, err := r.client.GetDeviceByMAC(ctx, resolvedSite, mac)
 	if err != nil {
 		resp.Diagnostics.AddError(
 			"Device Not Found",


### PR DESCRIPTION
## Summary
- Workaround for a go-unifi SDK bug where `DeviceRadioTable.TxPower` is declared as a string but the controller emits a JSON number for some APs, so every `terrifi_device` Read errored with `cannot unmarshal number into Go struct field .Alias.tx_power of type string` (issue #147).
- Adds `Client.GetDevice`/`GetDeviceByMAC`/`ListDevice` wrappers that fetch raw JSON via the existing `doV2Request` plumbing, wrap numeric `tx_power` values in quotes, then unmarshal into `unifi.Device`. Tagged with `TODO(go-unifi)` per the conventions in `CLAUDE.md`.
- Redirects all device-read call sites in `device_resource.go`, `device_data_source.go`, the radio merge in `device_api.go`, and `cmd/terrifi/generate_imports.go`.

## Test plan
- [x] `go build ./...`
- [x] `go vet ./...`
- [x] `task test:unit` (incl. new `TestFixTxPowerBytes` and `TestFixTxPowerBytes_decodesIntoUnifiDevice`)
- [ ] Verify on hardware: `terraform plan` against the controller from #147 no longer errors

Fixes #147.

🤖 Generated with [Claude Code](https://claude.com/claude-code)