### PR TITLE
Document how to test an unreleased terrifi CLI

### DIFF
--- a/docs/development.md
+++ b/docs/development.md
@@ -113,6 +113,45 @@ provider_installation {
 
 With `dev_overrides` active, skip `tofu init` and run `tofu plan` directly.
 
+## Testing an unreleased CLI
+
+The `terrifi` CLI (e.g., `terrifi generate-imports`) can be tested in two ways before a fix is released.
+
+### From a branch or pull request
+
+Build from source — useful for verifying a PR fix:
+
+```sh
+# A specific PR (e.g., #152):
+git fetch origin pull/152/head:pr-152 && git checkout pr-152
+
+# Or any branch:
+git checkout <branch>
+
+task build
+"$(go env GOBIN)/terrifi" generate-imports terrifi_device
+```
+
+`task build` installs the CLI to `$GOBIN`. Add `$GOBIN` to your `PATH` if you want to invoke `terrifi` directly.
+
+### From a pre-release GitHub release
+
+Pre-release tags (e.g. `v0.4.0-RC2`) publish a CLI archive named `terrifi-cli_<version>_<os>_<arch>.zip`:
+
+```sh
+VERSION="0.4.0-RC2"
+OS="linux"
+ARCH="amd64"
+OWNER="alexklibisz"
+PROVIDER="terraform-provider-terrifi"
+
+curl -L "https://github.com/${OWNER}/${PROVIDER}/releases/download/v${VERSION}/terrifi-cli_${VERSION}_${OS}_${ARCH}.zip" \
+  -o /tmp/terrifi-cli-${VERSION}.zip && \
+  unzip -o /tmp/terrifi-cli-${VERSION}.zip -d ~/terrifi-cli-${VERSION}/
+
+~/terrifi-cli-${VERSION}/terrifi --help
+```
+
 ## Releasing
 
 1. Go to the [Tag workflow](../../actions/workflows/tag.yml) in GitHub Actions.

--- a/docs/development.md
+++ b/docs/development.md
@@ -20,7 +20,7 @@ This does three things:
 2. Builds the `terrifi` CLI binary and installs it to your `GOBIN`
 3. Generates a `.terraformrc` file with `dev_overrides` pointing at the locally-built provider
 
-## Testing locally with a Terraform/OpenTofu project
+## Testing the provider locally with a Terraform/OpenTofu project
 
 After running `task build`, you can use the locally-built provider in any Terraform/OpenTofu project:
 
@@ -45,6 +45,44 @@ After running `task build`, you can use the locally-built provider in any Terraf
     ```
 
 The `dev_overrides` in `.terraformrc` tell Terraform/OpenTofu to use the locally-built binary instead of downloading from the registry. No `terraform init` or `tofu init` is needed.
+
+## Testing the CLI locally
+
+1. Build the CLI:
+
+    ```sh
+    $ cd /path/to/terrifi
+    $ task build:cli
+    ```
+
+2. Run it with `--version` to verify the install:
+
+    ```sh
+    $ terrifi --version
+    terrifi version v0.9.2-0.20260430142350-658b70734fe1
+    ```
+
+You should see a version that ends with a Git hash.
+
+### Switch back to the released CLI
+
+```sh
+$ go install github.com/alexklibisz/terrifi/cmd/terrifi@latest
+$ terrifi --version
+terrifi version v0.9.1
+```
+
+### Troubleshooting
+
+The `task build:cli` puts the binary ont
+If you don't, that means `task build:cli` wasn't able to get the binary onto your `$GOBIN`, or that your `$GOBIN` is not on your `$PATH`.
+
+```sh
+$ echo $GOBIN
+/Users/alex/.asdf/installs/golang/1.26.1/bin
+$ which terrifi
+/Users/alex/.asdf/installs/golang/1.26.1/bin/terrifi
+```
 
 ## Running tests
 
@@ -112,68 +150,6 @@ provider_installation {
 ```
 
 With `dev_overrides` active, skip `tofu init` and run `tofu plan` directly.
-
-## Testing an unreleased CLI
-
-The `terrifi` CLI (e.g., `terrifi generate-imports`) can be tested in two ways before a fix is released.
-
-### From a branch or pull request
-
-Build from source — useful for verifying a PR fix:
-
-```sh
-# A specific PR (e.g., #152):
-git fetch origin pull/152/head:pr-152 && git checkout pr-152
-
-# Or any branch:
-git checkout <branch>
-
-task build
-```
-
-`task build` installs the CLI to the same directory `go install` uses. That's `$GOBIN` if it's set, otherwise `$(go env GOPATH)/bin` (typically `~/go/bin`). The `Taskfile.yml` resolves this with `GOBIN=$(go env GOBIN); echo "${GOBIN:-$(go env GOPATH)/bin}"`.
-
-#### Run without changing your PATH
-
-Invoke the binary by its full path:
-
-```sh
-INSTALL_DIR="$(go env GOBIN)"
-INSTALL_DIR="${INSTALL_DIR:-$(go env GOPATH)/bin}"
-"$INSTALL_DIR/terrifi" generate-imports terrifi_device
-```
-
-#### Run as `terrifi` from anywhere
-
-Add the install dir to your `PATH`. For the current shell only:
-
-```sh
-INSTALL_DIR="$(go env GOBIN)"
-INSTALL_DIR="${INSTALL_DIR:-$(go env GOPATH)/bin}"
-export PATH="$INSTALL_DIR:$PATH"
-
-terrifi generate-imports terrifi_device
-```
-
-To make it persistent, append the same `export PATH=...` line to your shell's rc file (`~/.zshrc`, `~/.bashrc`, etc.) and start a new shell. Most Go developers already have `$(go env GOPATH)/bin` on their `PATH` for this reason.
-
-### From a pre-release GitHub release
-
-Pre-release tags (e.g. `v0.4.0-RC2`) publish a CLI archive named `terrifi-cli_<version>_<os>_<arch>.zip`:
-
-```sh
-VERSION="0.4.0-RC2"
-OS="linux"
-ARCH="amd64"
-OWNER="alexklibisz"
-PROVIDER="terraform-provider-terrifi"
-
-curl -L "https://github.com/${OWNER}/${PROVIDER}/releases/download/v${VERSION}/terrifi-cli_${VERSION}_${OS}_${ARCH}.zip" \
-  -o /tmp/terrifi-cli-${VERSION}.zip && \
-  unzip -o /tmp/terrifi-cli-${VERSION}.zip -d ~/terrifi-cli-${VERSION}/
-
-~/terrifi-cli-${VERSION}/terrifi --help
-```
 
 ## Releasing
 

--- a/docs/development.md
+++ b/docs/development.md
@@ -129,10 +129,33 @@ git fetch origin pull/152/head:pr-152 && git checkout pr-152
 git checkout <branch>
 
 task build
-"$(go env GOBIN)/terrifi" generate-imports terrifi_device
 ```
 
-`task build` installs the CLI to `$GOBIN`. Add `$GOBIN` to your `PATH` if you want to invoke `terrifi` directly.
+`task build` installs the CLI to the same directory `go install` uses. That's `$GOBIN` if it's set, otherwise `$(go env GOPATH)/bin` (typically `~/go/bin`). The `Taskfile.yml` resolves this with `GOBIN=$(go env GOBIN); echo "${GOBIN:-$(go env GOPATH)/bin}"`.
+
+#### Run without changing your PATH
+
+Invoke the binary by its full path:
+
+```sh
+INSTALL_DIR="$(go env GOBIN)"
+INSTALL_DIR="${INSTALL_DIR:-$(go env GOPATH)/bin}"
+"$INSTALL_DIR/terrifi" generate-imports terrifi_device
+```
+
+#### Run as `terrifi` from anywhere
+
+Add the install dir to your `PATH`. For the current shell only:
+
+```sh
+INSTALL_DIR="$(go env GOBIN)"
+INSTALL_DIR="${INSTALL_DIR:-$(go env GOPATH)/bin}"
+export PATH="$INSTALL_DIR:$PATH"
+
+terrifi generate-imports terrifi_device
+```
+
+To make it persistent, append the same `export PATH=...` line to your shell's rc file (`~/.zshrc`, `~/.bashrc`, etc.) and start a new shell. Most Go developers already have `$(go env GOPATH)/bin` on their `PATH` for this reason.
 
 ### From a pre-release GitHub release
 


### PR DESCRIPTION
## Summary
- Adds a "Testing an unreleased CLI" section to `docs/development.md` covering:
  - Building from a branch or PR via `task build`
  - Downloading the `terrifi-cli_*.zip` archive from a pre-release GitHub release

The existing pre-release section only covered the provider binary. This documents the parallel path for the CLI (`terrifi generate-imports`), which users may want to run to verify a fix before a release ships.

## Test plan
- [x] `docs/development.md` renders cleanly on GitHub
- [ ] Walk through the "from branch" instructions on a fresh checkout

🤖 Generated with [Claude Code](https://claude.com/claude-code)