### PR TITLE
Make CI workflows fork-friendly (§0 CF01/CF02/CF03)

### DIFF
--- a/.github/workflows/ci-hil.yaml
+++ b/.github/workflows/ci-hil.yaml
@@ -1,15 +1,15 @@
-name: CI - HIL
-
 # Hardware-in-the-loop tests. They run on a self-hosted runner with the labels
 # below, wired to a real UniFi controller — infrastructure that only exists in
 # the upstream repo. The `if:` guard on the job keeps this inert in forks:
 # without it, a fork's PR/schedule queues a job that can never be scheduled
 # (no matching runner), leaving the required check stuck "Expected" forever.
 #
-# To opt a fork into HIL: (1) replace the repository name in the `if:` guard
-# below with your own `owner/repo`; (2) register a self-hosted runner with the
-# `self-hosted` + `terrifi-hardware-test` labels, pointed at your controller;
-# (3) add the `TERRIFI_HIL_TEST_UNIFI_API_KEY` secret.
+# To opt a fork into HIL:
+# 1. replace the repository name in the `if:` guard below with your own `owner/repo`
+# 2. register a self-hosted runner with the `self-hosted` + `terrifi-hardware-test` labels, pointed at your controller
+# 3. add the `TERRIFI_HIL_TEST_UNIFI_API_KEY` secret in https://github.com/<owner/repo>/settings/secrets/actions.
+
+name: CI - HIL
 
 concurrency:
   group: ${{ github.workflow }}

--- a/.github/workflows/ci-hil.yaml
+++ b/.github/workflows/ci-hil.yaml
@@ -1,7 +1,18 @@
 name: CI - HIL
 
+# Hardware-in-the-loop tests. They run on a self-hosted runner with the labels
+# below, wired to a real UniFi controller — infrastructure that only exists in
+# the upstream repo. The `if:` guard on the job keeps this inert in forks:
+# without it, a fork's PR/schedule queues a job that can never be scheduled
+# (no matching runner), leaving the required check stuck "Expected" forever.
+#
+# To opt a fork into HIL: (1) replace the repository name in the `if:` guard
+# below with your own `owner/repo`; (2) register a self-hosted runner with the
+# `self-hosted` + `terrifi-hardware-test` labels, pointed at your controller;
+# (3) add the `TERRIFI_HIL_TEST_UNIFI_API_KEY` secret.
+
 concurrency:
-  group: ${{ github.workflow }} 
+  group: ${{ github.workflow }}
   cancel-in-progress: false
 
 on:
@@ -14,6 +25,8 @@ on:
 jobs:
   main:
     name: Main
+    # Skip everywhere except the upstream repo — see header.
+    if: github.repository == 'alexklibisz/terraform-provider-terrifi'
     runs-on:
       - self-hosted
       - terrifi-hardware-test

--- a/.github/workflows/deploy-site.yaml
+++ b/.github/workflows/deploy-site.yaml
@@ -1,5 +1,3 @@
-name: Deploy Site
-
 # Builds and publishes the device-types GitHub Pages site. It runs on the
 # self-hosted HIL runner (it needs a real controller to enumerate device
 # types) and deploys to the upstream repo's Pages environment. The `if:`
@@ -7,9 +5,14 @@ name: Deploy Site
 # the watched paths queues a job that can't schedule (no runner, no Pages
 # env, no secret), leaving a permanent red X on the fork's history.
 #
-# To opt a fork in: replace the repository name in the `if:` guard, register
-# the self-hosted runner (see ci-hil.yaml), enable Pages, and add the
-# TERRIFI_HIL_TEST_UNIFI_API_KEY secret.
+# To opt a fork in:
+# 1. replace the repository name in the `if:` guard
+# 2. register a self-hosted runner (see ci-hil.yaml)
+# 3. enable Github Pages in https://github.com/<owner/repo>/settings/pages
+# 4. add the TERRIFI_HIL_TEST_UNIFI_API_KEY secret in 
+#    https://github.com/<owner/repo>/settings/secrets/actions.
+
+name: Deploy Site
 
 on:
   workflow_dispatch:

--- a/.github/workflows/deploy-site.yaml
+++ b/.github/workflows/deploy-site.yaml
@@ -1,5 +1,16 @@
 name: Deploy Site
 
+# Builds and publishes the device-types GitHub Pages site. It runs on the
+# self-hosted HIL runner (it needs a real controller to enumerate device
+# types) and deploys to the upstream repo's Pages environment. The `if:`
+# guard keeps it inert in forks: without it, a push to a fork's main touching
+# the watched paths queues a job that can't schedule (no runner, no Pages
+# env, no secret), leaving a permanent red X on the fork's history.
+#
+# To opt a fork in: replace the repository name in the `if:` guard, register
+# the self-hosted runner (see ci-hil.yaml), enable Pages, and add the
+# TERRIFI_HIL_TEST_UNIFI_API_KEY secret.
+
 on:
   workflow_dispatch:
   push:
@@ -21,6 +32,8 @@ concurrency:
 jobs:
   deploy:
     name: Deploy
+    # Skip everywhere except the upstream repo — see header.
+    if: github.repository == 'alexklibisz/terraform-provider-terrifi'
     runs-on:
       - self-hosted
       - terrifi-hardware-test

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,21 +1,7 @@
-name: Release
-
+# Builds and releases the current ref as a Github release.
 # Tags the current ref, builds the provider with GoReleaser, and publishes a
 # signed GitHub Release that the Terraform/OpenTofu registries can index.
-#
-# Required repository secrets (Settings → Secrets and variables → Actions):
-#   GPG_PRIVATE_KEY  — ASCII-armored private key used to sign the checksums.
-#                      Its public half must be registered with the registry
-#                      under your provider namespace.
-#   GPG_PASSPHRASE   — passphrase for that key.
-# Generate a key with `gpg --full-generate-key`, export the private half with
-# `gpg --armor --export-secret-keys <KEYID>`, and register the public half
-# with the OpenTofu/Terraform registry for your namespace.
-#
-# workflow_dispatch is the only trigger, so this stays inert in a fork until
-# someone explicitly runs it from the Actions tab. The "Check secrets" step
-# below fails fast with a clear message if the secrets are missing, instead of
-# erroring cryptically mid-run inside GoReleaser's GPG signing.
+name: Release
 
 on:
   workflow_dispatch:
@@ -32,6 +18,8 @@ jobs:
     name: Release
     runs-on: ubuntu-24.04
     steps:
+      # Check for expected secrets and error with a useful message instead 
+      # of failing cryptically in the build/release steps.
       - name: Check required secrets
         env:
           GPG_PRIVATE_KEY: ${{ secrets.GPG_PRIVATE_KEY }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,5 +1,22 @@
 name: Release
 
+# Tags the current ref, builds the provider with GoReleaser, and publishes a
+# signed GitHub Release that the Terraform/OpenTofu registries can index.
+#
+# Required repository secrets (Settings → Secrets and variables → Actions):
+#   GPG_PRIVATE_KEY  — ASCII-armored private key used to sign the checksums.
+#                      Its public half must be registered with the registry
+#                      under your provider namespace.
+#   GPG_PASSPHRASE   — passphrase for that key.
+# Generate a key with `gpg --full-generate-key`, export the private half with
+# `gpg --armor --export-secret-keys <KEYID>`, and register the public half
+# with the OpenTofu/Terraform registry for your namespace.
+#
+# workflow_dispatch is the only trigger, so this stays inert in a fork until
+# someone explicitly runs it from the Actions tab. The "Check secrets" step
+# below fails fast with a clear message if the secrets are missing, instead of
+# erroring cryptically mid-run inside GoReleaser's GPG signing.
+
 on:
   workflow_dispatch:
     inputs:
@@ -15,6 +32,19 @@ jobs:
     name: Release
     runs-on: ubuntu-24.04
     steps:
+      - name: Check required secrets
+        env:
+          GPG_PRIVATE_KEY: ${{ secrets.GPG_PRIVATE_KEY }}
+          GPG_PASSPHRASE: ${{ secrets.GPG_PASSPHRASE }}
+        run: |
+          missing=
+          [ -z "$GPG_PRIVATE_KEY" ] && missing="$missing GPG_PRIVATE_KEY"
+          [ -z "$GPG_PASSPHRASE" ] && missing="$missing GPG_PASSPHRASE"
+          if [ -n "$missing" ]; then
+            echo "::error::Missing required release secret(s):$missing. See the header comment in .github/workflows/release.yml for how to set them."
+            exit 1
+          fi
+          echo "Required release secrets are present."
       - name: Checkout
         uses: actions/checkout@v6
         with:


### PR DESCRIPTION
## Summary

Makes the three workflows that assume upstream-only infrastructure (self-hosted HIL runner, GitHub Pages environment, signing secrets) **fork-friendly**, so a fork or external PR doesn't hang, queue unschedulable jobs, or leave permanent red ❌ marks. Implements §0 (CF01/CF02/CF03) of the improvement plan. No behavior change in this repo — every job still runs here exactly as before.

## Changes

- **CF01 — `ci-hil.yaml`**: gate the `main` job with `if: github.repository == 'alexklibisz/terraform-provider-terrifi'`. Without it, a fork's `pull_request`/`schedule` trigger queues a job on a `self-hosted, terrifi-hardware-test` runner that only exists here, so the required check sits "Expected" forever. Header comment explains how a fork opts into HIL (own runner labels + `TERRIFI_HIL_TEST_UNIFI_API_KEY`).
- **CF02 — `deploy-site.yaml`**: same `if:` gate on the `deploy` job. A fork push touching `site/**`, `cmd/terrifi/list_device_types.go`, `internal/provider/fingerprint_api.go`, or the workflow itself currently queues a Pages deploy that can't schedule (no runner, no Pages env, no secret) — a permanent red X on the fork's history.
- **CF03 — `release.yml`**: add a header documenting the required `GPG_PRIVATE_KEY` / `GPG_PASSPHRASE` secrets and how to generate/register them, plus a first **"Check required secrets"** step that fails fast with an actionable message when they're unset — instead of a cryptic mid-run GoReleaser GPG error. `workflow_dispatch` stays the only trigger (already inert in forks until invoked).

## Test plan

- All three YAMLs validated (parse + correct `if:` placement on the `main`/`deploy` jobs; `release` job intentionally ungated, guarded by the secret-check step).
- No-op in this repo: `github.repository == 'alexklibisz/terraform-provider-terrifi'` is true here, so HIL and deploy-site run unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
