### PR TITLE
client_device: make note optional+computed so controller-set notes apply (#165)

### DIFF
--- a/docs/resources/client_device.md
+++ b/docs/resources/client_device.md
@@ -127,7 +127,7 @@ resource "terrifi_client_device" "blocked" {
 ### Optional
 
 - `name` (String) — The alias/display name for the client device.
-- `note` (String) — A free-text note for the client device.
+- `note` (String) — A free-text note for the client device. Optional *and* computed: when the configuration does not set it, whatever note the controller already holds (for example one added through the UI) is adopted into state instead of being reported as drift. Removing `note` from the configuration therefore does **not** clear it on the controller — the API exposes no clear-a-note operation. An empty string is rejected, because the controller drops it from the request and it would read back as null.
 - `fixed_ip` (String) — A fixed IP address to assign via DHCP reservation. Requires `network_id` or `network_override_id`.
 - `network_id` (String) — The network ID for fixed IP assignment. Required when `fixed_ip` is set unless `network_override_id` provides the network context.
 - `network_override_id` (String) — The network ID for VLAN/network override.

--- a/internal/provider/client_device_resource.go
+++ b/internal/provider/client_device_resource.go
@@ -107,8 +107,23 @@ func (r *clientDeviceResource) Schema(
 			},
 
 			"note": schema.StringAttribute{
-				MarkdownDescription: "A free-text note for the client device.",
-				Optional:            true,
+				MarkdownDescription: "A free-text note for the client device.\n\n" +
+					"This attribute is optional *and* computed: when the configuration does not " +
+					"set it, whatever note the controller already holds (for example one added " +
+					"through the UI) is adopted into state instead of being reported as drift. " +
+					"Removing `note` from the configuration therefore does not clear it on the " +
+					"controller — the API exposes no clear-a-note operation.",
+				Optional: true,
+				Computed: true,
+				PlanModifiers: []planmodifier.String{
+					stringplanmodifier.UseStateForUnknown(),
+				},
+				Validators: []validator.String{
+					// The controller drops an empty note from the request body, so it
+					// would read back as null and contradict a planned "". Reject it at
+					// validate time rather than failing after apply.
+					stringvalidator.LengthAtLeast(1),
+				},
 			},
 
 			"fixed_ip": schema.StringAttribute{
@@ -504,10 +519,13 @@ func (r *clientDeviceResource) applyPlanToState(plan, state *clientDeviceResourc
 	} else {
 		state.Name = types.StringNull()
 	}
-	if !plan.Note.IsNull() && !plan.Note.IsUnknown() {
+	// note is optional+computed, so an absent config value plans as unknown
+	// rather than null. Copy only when known and let apiToModel hydrate the
+	// unknown case from the controller's response; forcing null here is what
+	// produced "provider produced inconsistent result after apply" whenever the
+	// controller held a note the configuration did not set.
+	if !plan.Note.IsUnknown() {
 		state.Note = plan.Note
-	} else {
-		state.Note = types.StringNull()
 	}
 	if !plan.FixedIP.IsNull() && !plan.FixedIP.IsUnknown() {
 		state.FixedIP = plan.FixedIP

--- a/internal/provider/client_device_resource_test.go
+++ b/internal/provider/client_device_resource_test.go
@@ -5,6 +5,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"math/rand"
+	"regexp"
 	"testing"
 
 	"github.com/hashicorp/terraform-plugin-framework/attr"
@@ -643,9 +644,93 @@ func TestClientDeviceAPIToModel(t *testing.T) {
 	})
 }
 
+// TestClientDeviceNoteRoundTrip covers the note attribute's optional+computed
+// semantics. Before that change a controller-side note that the configuration
+// did not set produced "provider produced inconsistent result after apply":
+// applyPlanToState forced state.Note to null, then apiToModel overwrote it with
+// the controller's value, and unlike client_group_ids / network_id /
+// device_type_id the Update path never restored the planned value.
+func TestClientDeviceNoteRoundTrip(t *testing.T) {
+	r := &clientDeviceResource{}
+
+	t.Run("apiToModel adopts a note the model never set", func(t *testing.T) {
+		c := &unifi.Client{ID: "c1", MAC: "aa:bb:cc:dd:ee:ff", Note: "Ethernet"}
+
+		var model clientDeviceResourceModel
+		r.apiToModel(c, &model, "default")
+
+		assert.Equal(t, "Ethernet", model.Note.ValueString())
+	})
+
+	t.Run("apiToModel maps an absent note to null, not empty string", func(t *testing.T) {
+		c := &unifi.Client{ID: "c1", MAC: "aa:bb:cc:dd:ee:ff"}
+
+		var model clientDeviceResourceModel
+		r.apiToModel(c, &model, "default")
+
+		assert.True(t, model.Note.IsNull())
+	})
+
+	t.Run("modelToAPI omits the note when the model has none", func(t *testing.T) {
+		ctx := context.Background()
+		m := &clientDeviceResourceModel{
+			MAC:  types.StringValue("aa:bb:cc:dd:ee:ff"),
+			Note: types.StringNull(),
+		}
+
+		c := r.modelToAPI(ctx, m)
+
+		assert.Empty(t, c.Note, "an unset note must not be written back to the controller")
+	})
+
+	t.Run("applyPlanToState keeps prior state when the plan is unknown", func(t *testing.T) {
+		// No note in config -> the framework plans unknown. The prior value has
+		// to survive so apiToModel's hydration is not contradicted.
+		plan := &clientDeviceResourceModel{Note: types.StringUnknown()}
+		state := &clientDeviceResourceModel{Note: types.StringValue("Ethernet")}
+
+		r.applyPlanToState(plan, state)
+
+		assert.Equal(t, "Ethernet", state.Note.ValueString())
+	})
+
+	t.Run("applyPlanToState takes the planned note when it is known", func(t *testing.T) {
+		plan := &clientDeviceResourceModel{Note: types.StringValue("new note")}
+		state := &clientDeviceResourceModel{Note: types.StringValue("old note")}
+
+		r.applyPlanToState(plan, state)
+
+		assert.Equal(t, "new note", state.Note.ValueString())
+	})
+
+	t.Run("applyPlanToState propagates an explicitly null plan", func(t *testing.T) {
+		// UseStateForUnknown only fires for unknown values. A genuinely null
+		// plan (no prior state to borrow from) must not be turned into a value.
+		plan := &clientDeviceResourceModel{Note: types.StringNull()}
+		state := &clientDeviceResourceModel{Note: types.StringValue("stale")}
+
+		r.applyPlanToState(plan, state)
+
+		assert.True(t, state.Note.IsNull())
+	})
+}
+
 // ---------------------------------------------------------------------------
 // Acceptance tests — require TF_ACC=1 and a UniFi controller
 // ---------------------------------------------------------------------------
+
+// testAccRawClient builds a provider Client straight from the environment so a
+// test can mutate the controller outside Terraform's knowledge. Used to set up
+// pre-existing state that no Terraform configuration ever created.
+func testAccRawClient(t *testing.T) *Client {
+	t.Helper()
+
+	cfg := ClientConfigFromEnv()
+	c, err := NewClient(context.Background(), cfg)
+	require.NoError(t, err, "building a raw UniFi client from the environment")
+
+	return c
+}
 
 func TestAccClientDevice_basic(t *testing.T) {
 	mac := randomMAC()
@@ -689,6 +774,136 @@ resource "terrifi_client_device" "test" {
 					resource.TestCheckResourceAttr("terrifi_client_device.test", "name", "tfacc-note"),
 					resource.TestCheckResourceAttr("terrifi_client_device.test", "note", "This is a test note"),
 				),
+			},
+			{
+				// A note set through Terraform must survive an import round-trip.
+				ResourceName:      "terrifi_client_device.test",
+				ImportState:       true,
+				ImportStateVerify: true,
+			},
+		},
+	})
+}
+
+// TestAccClientDevice_noteRemovedFromConfig removes note from the configuration
+// after it was set. Because note is computed, the controller's value is adopted
+// rather than cleared, and the plan settles empty. Before the optional+computed
+// change this failed the second step with "provider produced inconsistent
+// result after apply".
+func TestAccClientDevice_noteRemovedFromConfig(t *testing.T) {
+	mac := randomMAC()
+
+	withNote := fmt.Sprintf(`
+resource "terrifi_client_device" "test" {
+  mac  = %q
+  name = "tfacc-note-removed"
+  note = "tfacc-note-v1"
+}
+`, mac)
+
+	withoutNote := fmt.Sprintf(`
+resource "terrifi_client_device" "test" {
+  mac  = %q
+  name = "tfacc-note-removed"
+}
+`, mac)
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:                 func() { preCheck(t) },
+		ProtoV6ProviderFactories: testAccProtoV6ProviderFactories,
+		Steps: []resource.TestStep{
+			{
+				Config: withNote,
+				Check: resource.TestCheckResourceAttr(
+					"terrifi_client_device.test", "note", "tfacc-note-v1"),
+			},
+			{
+				Config: withoutNote,
+				Check: resource.TestCheckResourceAttr(
+					"terrifi_client_device.test", "note", "tfacc-note-v1"),
+			},
+			{
+				// And the adopted value must be stable, not a perpetual diff.
+				Config:   withoutNote,
+				PlanOnly: true,
+			},
+		},
+	})
+}
+
+// TestAccClientDevice_noteSetOutsideTerraform is the real-world shape of the
+// bug: a note that arrived through the UI on a client whose configuration never
+// mentioned one. The note is written with a raw client so Terraform genuinely
+// does not know about it until the next refresh.
+func TestAccClientDevice_noteSetOutsideTerraform(t *testing.T) {
+	mac := randomMAC()
+	var clientID string
+
+	config := fmt.Sprintf(`
+resource "terrifi_client_device" "test" {
+  mac  = %q
+  name = "tfacc-note-external"
+}
+`, mac)
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:                 func() { preCheck(t) },
+		ProtoV6ProviderFactories: testAccProtoV6ProviderFactories,
+		Steps: []resource.TestStep{
+			{
+				Config: config,
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckNoResourceAttr("terrifi_client_device.test", "note"),
+					func(s *terraform.State) error {
+						rs, ok := s.RootModule().Resources["terrifi_client_device.test"]
+						if !ok {
+							return fmt.Errorf("terrifi_client_device.test missing from state")
+						}
+						clientID = rs.Primary.Attributes["id"]
+						return nil
+					},
+				),
+			},
+			{
+				PreConfig: func() {
+					ctx := context.Background()
+					c := testAccRawClient(t)
+					site := c.SiteOrDefault(types.StringNull())
+
+					d, err := c.GetClientDevice(ctx, site, clientID)
+					require.NoError(t, err, "reading the client back for the out-of-band write")
+
+					d.Note = "added-in-the-ui"
+					_, err = c.UpdateClientDevice(ctx, site, d)
+					require.NoError(t, err, "writing the note outside Terraform")
+				},
+				Config: config,
+				Check: resource.TestCheckResourceAttr(
+					"terrifi_client_device.test", "note", "added-in-the-ui"),
+			},
+		},
+	})
+}
+
+// TestAccClientDevice_noteEmptyRejected guards the length validator. The
+// controller drops an empty note from the request body, so it would read back
+// as null and contradict a planned "" — the same inconsistency in a new
+// disguise. Rejecting it at validate time is cheaper than failing after apply.
+func TestAccClientDevice_noteEmptyRejected(t *testing.T) {
+	mac := randomMAC()
+	resource.Test(t, resource.TestCase{
+		PreCheck:                 func() { preCheck(t) },
+		ProtoV6ProviderFactories: testAccProtoV6ProviderFactories,
+		Steps: []resource.TestStep{
+			{
+				Config: fmt.Sprintf(`
+resource "terrifi_client_device" "test" {
+  mac  = %q
+  name = "tfacc-note-empty"
+  note = ""
+}
+`, mac),
+				ExpectError: regexp.MustCompile(`(?s)note.*at least 1`),
 			},
 		},
 	})


### PR DESCRIPTION
Fixes #165.

This is the first of the small standalone fixes you asked for in #160 — filed separately from the SDK work, and based on `main` rather than stacked on #161, so it's reviewable and mergeable on its own.

## The bug

Apply a `terrifi_client_device` whose controller record already has a `note` that your config doesn't set, and it fails:

```
Error: Provider produced inconsistent result after apply

When applying changes to terrifi_client_device.foo, provider produced an
unexpected new value: .note: was null, but now cty.StringVal("Ethernet").
```

You hit this whenever you import clients that were originally set up through the UI — someone typed a note in years ago, your HCL doesn't mention `note`, and the apply dies. The usual workaround is `lifecycle { ignore_changes = [note] }`.

## Root cause

In `Update()`, `applyPlanToState()` runs first and forced `state.Note` to null when the plan had none. Then `apiToModel()` runs and overwrites it with the controller's value. `client_group_ids`, `network_id` and `device_type_id` are explicitly restored from saved planned values after `apiToModel()` — `note` never was. So the controller's value survives into the applied state and contradicts the plan.

## The fix

`note` becomes `Optional + Computed`, so adopting the controller's value is the declared behaviour instead of a surprise. Two details that aren't obvious:

- **`UseStateForUnknown()` is required, not cosmetic.** Without it, a computed attribute with no config value plans as unknown on every single plan — you'd get `note = (known after apply)` forever and never a clean zero-diff.
- **`applyPlanToState` becomes copy-if-*known* rather than copy-if-*set*.** An absent config value now plans as unknown, not null, and has to defer to `apiToModel`'s hydration. A genuinely null plan still propagates, so this isn't a blanket "never clear anything".

It also rejects `note = ""` at validate time. `buildClientDeviceRequest` drops an empty note from the body (`json:"note,omitempty"`), so `""` would read back as null and reproduce the same inconsistency wearing a different hat. Better to say so during validate than after apply.

## This doesn't take anything away

Worth being explicit, since `Optional + Computed` normally means "you can no longer clear this": **there was never a way to clear a note through the provider.** The request field has always been `omitempty`, so an empty note was already dropped rather than sent. The old code didn't clear the note — it crashed. Now the behaviour is stated in the schema description and in `docs/resources/client_device.md`.

## Tests

Unit tests cover the full matrix, including the unknown-vs-null distinction that the plan modifier depends on:

- `apiToModel` adopts a note the model never set / maps an absent note to null rather than `""`
- `modelToAPI` omits an unset note
- `applyPlanToState` keeps prior state on unknown, takes the planned value when known, and still propagates an explicit null

Acceptance tests:

- `TestAccClientDevice_noteRemovedFromConfig` — set a note, delete the line from the config, re-apply. This is the CI-visible regression: it fails on `main` today with the error above. Third step is `PlanOnly` to prove the adopted value is stable and not a perpetual diff.
- `TestAccClientDevice_noteSetOutsideTerraform` — the real-world shape. Creates a client with no note, then writes one with a raw client so Terraform genuinely doesn't know about it, then re-applies the unchanged config. Needed a small `testAccRawClient(t)` helper; it's reusable for any other "controller changed under us" test.
- `TestAccClientDevice_noteEmptyRejected` — guards the validator.
- An import round-trip step added to the existing `TestAccClientDevice_note`.

## What I ran

`go build`, `go vet`, and the full unit suite pass. I can't run your HIL rig, and I know fork PRs can't reach the API-key secret (per your comment on #164) — so the acceptance tests here are unverified against real hardware and I'd treat that as the gate. I do have a UniFi OS Server bench I can run the acceptance suite against if that's useful as a second signal; happy to post results.

Written with Claude Code, reviewed by me — same disclosure as on #159.
