### PR TITLE
test: put the Docker acceptance bootstrap behind an `acc` build tag

### DIFF
--- a/Taskfile.yml
+++ b/Taskfile.yml
@@ -51,7 +51,10 @@ tasks:
       TF_ACC: "1"
       TERRIFI_ACC_TARGET: docker
     cmds:
-      - go test ./internal/provider/ -v -count 1 -shuffle=on -timeout 10m -run "^TestAcc" {{.CLI_ARGS}}
+      # -tags=acc pulls in the testcontainers/compose bootstrap. Only this
+      # target needs it; the hardware target talks to an existing controller,
+      # so leaving the tag off keeps the Docker tree out of its build.
+      - go test -tags=acc ./internal/provider/ -v -count 1 -shuffle=on -timeout 10m -run "^TestAcc" {{.CLI_ARGS}}
 
   test:acc:hardware:
     desc: Run acceptance tests against real hardware (uses env vars from .envrc.local)
@@ -91,6 +94,9 @@ tasks:
     desc: Run static analysis
     cmds:
       - go vet ./...
+      # Also vet the acc-tagged Docker bootstrap, which the untagged pass skips.
+      # Without this it would rot silently until someone ran test:acc.
+      - go vet -tags=acc ./internal/provider/
 
   checkAPIConnection:
     desc: Verify connectivity to the UniFi controller

--- a/internal/provider/provider_docker_acc_test.go
+++ b/internal/provider/provider_docker_acc_test.go
@@ -1,0 +1,130 @@
+//go:build acc
+
+// The Docker acceptance bootstrap lives behind the `acc` build tag so that
+// testcontainers-go/modules/compose — and the containerd/docker/compose-go tree
+// it pulls in — is only compiled when it is actually going to be used. Without
+// the tag, `go test ./...` builds the whole Docker stack just to run unit tests.
+//
+// Run the Docker acceptance target with:
+//
+//	go test -tags=acc ./internal/provider/ -run TestAcc
+//
+// The Taskfile's test:acc* targets pass the tag for you.
+
+package provider
+
+import (
+	"context"
+	"fmt"
+	"os"
+	"testing"
+	"time"
+
+	"github.com/testcontainers/testcontainers-go/modules/compose"
+	"github.com/ubiquiti-community/go-unifi/unifi"
+)
+
+// runDockerTests starts a UniFi controller in Docker, waits for it to be ready,
+// sets the env vars that the provider reads, runs all tests, then tears down.
+func runDockerTests(m *testing.M) int {
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	// Start the Docker Compose stack (docker-compose.yaml in project root).
+	dc, err := compose.NewDockerCompose("../../docker-compose.yaml")
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "failed to create docker compose: %s\n", err)
+		return 1
+	}
+
+	// Tear down containers when we're done, regardless of test results.
+	defer func() {
+		fmt.Println("Tearing down Docker containers...")
+		if err := dc.Down(context.Background(), compose.RemoveOrphans(true)); err != nil {
+			fmt.Fprintf(os.Stderr, "failed to tear down: %s\n", err)
+		}
+	}()
+
+	fmt.Println("Starting UniFi controller in Docker...")
+	if err := dc.Up(ctx, compose.Wait(true)); err != nil {
+		fmt.Fprintf(os.Stderr, "failed to start docker compose: %s\n", err)
+		return 1
+	}
+
+	// Get the container's mapped port. Docker maps the container's 8443 to a
+	// random host port to avoid conflicts with other services.
+	container, err := dc.ServiceContainer(ctx, "unifi")
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "failed to get container: %s\n", err)
+		return 1
+	}
+
+	host, err := container.Host(ctx)
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "failed to get host: %s\n", err)
+		return 1
+	}
+
+	mappedPort, err := container.MappedPort(ctx, "8443/tcp")
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "failed to get mapped port: %s\n", err)
+		return 1
+	}
+
+	endpoint := fmt.Sprintf("https://%s:%s", host, mappedPort.Port())
+
+	// Set the env vars that our provider reads in Configure().
+	// These override anything from .envrc since we want tests to hit Docker.
+	os.Setenv("UNIFI_USERNAME", "admin")
+	os.Setenv("UNIFI_PASSWORD", "admin")
+	os.Setenv("UNIFI_API", endpoint)
+	os.Setenv("UNIFI_INSECURE", "true")
+	os.Setenv("UNIFI_SITE", "default")
+	os.Setenv("UNIFI_API_KEY", "") // Clear any API key from env
+
+	// Wait for the UniFi API to be fully operational. The container may be
+	// "healthy" per Docker but the API might not be ready yet.
+	fmt.Printf("Waiting for UniFi API at %s...\n", endpoint)
+	if err := waitForAPI(ctx, endpoint, "admin", "admin"); err != nil {
+		fmt.Fprintf(os.Stderr, "API never became ready: %s\n", err)
+		return 1
+	}
+
+	fmt.Println("UniFi API ready, running tests...")
+	return m.Run()
+}
+
+// waitForAPI polls the UniFi API until login succeeds and basic endpoints respond.
+// The controller can take 60-120 seconds to initialize after Docker reports healthy.
+func waitForAPI(ctx context.Context, endpoint, user, pass string) error {
+	maxRetries := 60
+	retryDelay := 3 * time.Second
+
+	for i := range maxRetries {
+		client, err := unifi.New(ctx, &unifi.Config{
+			BaseURL:       endpoint,
+			Username:      user,
+			Password:      pass,
+			AllowInsecure: true,
+		})
+		if err != nil {
+			if i%10 == 0 {
+				fmt.Printf("  attempt %d/%d: login failed (%s), retrying...\n", i+1, maxRetries, err)
+			}
+			time.Sleep(retryDelay)
+			continue
+		}
+
+		// Verify the sites endpoint responds (confirms the network application is ready).
+		if _, err := client.ListSites(ctx); err != nil {
+			fmt.Printf("  attempt %d/%d: login OK but sites not ready (%s)\n", i+1, maxRetries, err)
+			time.Sleep(retryDelay)
+			continue
+		}
+
+		fmt.Printf("  API ready after %d attempts\n", i+1)
+		return nil
+	}
+
+	return fmt.Errorf("API not ready after %d attempts (%v total)", maxRetries, time.Duration(maxRetries)*retryDelay)
+}

--- a/internal/provider/provider_docker_stub_test.go
+++ b/internal/provider/provider_docker_stub_test.go
@@ -1,0 +1,23 @@
+//go:build !acc
+
+package provider
+
+import (
+	"fmt"
+	"os"
+	"testing"
+)
+
+// runDockerTests is a stub for builds without the `acc` tag. The real
+// implementation lives in provider_docker_acc_test.go and is the only thing in
+// this module that imports testcontainers-go/modules/compose.
+//
+// TestMain stays untagged so unit tests keep running normally; only the Docker
+// bootstrap is tag-gated.
+func runDockerTests(_ *testing.M) int {
+	fmt.Fprintln(os.Stderr,
+		"TERRIFI_ACC_TARGET=docker requires the `acc` build tag: go test -tags=acc ./... "+
+			"(or use the Taskfile's test:acc targets). Use TERRIFI_ACC_TARGET=hardware "+
+			"or TERRIFI_ACC_TARGET=uos to run against an existing controller instead.")
+	return 1
+}

--- a/internal/provider/provider_test.go
+++ b/internal/provider/provider_test.go
@@ -1,16 +1,12 @@
 package provider
 
 import (
-	"context"
 	"fmt"
 	"os"
 	"testing"
-	"time"
 
 	"github.com/hashicorp/terraform-plugin-framework/providerserver"
 	"github.com/hashicorp/terraform-plugin-go/tfprotov6"
-	"github.com/testcontainers/testcontainers-go/modules/compose"
-	"github.com/ubiquiti-community/go-unifi/unifi"
 )
 
 // testAccProtoV6ProviderFactories creates a provider factory for acceptance tests.
@@ -50,111 +46,6 @@ func TestMain(m *testing.M) {
 		fmt.Fprintf(os.Stderr, "unknown TERRIFI_ACC_TARGET: %s (expected 'docker' or 'hardware')\n", target)
 		os.Exit(1)
 	}
-}
-
-// runDockerTests starts a UniFi controller in Docker, waits for it to be ready,
-// sets the env vars that the provider reads, runs all tests, then tears down.
-func runDockerTests(m *testing.M) int {
-	ctx, cancel := context.WithCancel(context.Background())
-	defer cancel()
-
-	// Start the Docker Compose stack (docker-compose.yaml in project root).
-	dc, err := compose.NewDockerCompose("../../docker-compose.yaml")
-	if err != nil {
-		fmt.Fprintf(os.Stderr, "failed to create docker compose: %s\n", err)
-		return 1
-	}
-
-	// Tear down containers when we're done, regardless of test results.
-	defer func() {
-		fmt.Println("Tearing down Docker containers...")
-		if err := dc.Down(context.Background(), compose.RemoveOrphans(true)); err != nil {
-			fmt.Fprintf(os.Stderr, "failed to tear down: %s\n", err)
-		}
-	}()
-
-	fmt.Println("Starting UniFi controller in Docker...")
-	if err := dc.Up(ctx, compose.Wait(true)); err != nil {
-		fmt.Fprintf(os.Stderr, "failed to start docker compose: %s\n", err)
-		return 1
-	}
-
-	// Get the container's mapped port. Docker maps the container's 8443 to a
-	// random host port to avoid conflicts with other services.
-	container, err := dc.ServiceContainer(ctx, "unifi")
-	if err != nil {
-		fmt.Fprintf(os.Stderr, "failed to get container: %s\n", err)
-		return 1
-	}
-
-	host, err := container.Host(ctx)
-	if err != nil {
-		fmt.Fprintf(os.Stderr, "failed to get host: %s\n", err)
-		return 1
-	}
-
-	mappedPort, err := container.MappedPort(ctx, "8443/tcp")
-	if err != nil {
-		fmt.Fprintf(os.Stderr, "failed to get mapped port: %s\n", err)
-		return 1
-	}
-
-	endpoint := fmt.Sprintf("https://%s:%s", host, mappedPort.Port())
-
-	// Set the env vars that our provider reads in Configure().
-	// These override anything from .envrc since we want tests to hit Docker.
-	os.Setenv("UNIFI_USERNAME", "admin")
-	os.Setenv("UNIFI_PASSWORD", "admin")
-	os.Setenv("UNIFI_API", endpoint)
-	os.Setenv("UNIFI_INSECURE", "true")
-	os.Setenv("UNIFI_SITE", "default")
-	os.Setenv("UNIFI_API_KEY", "") // Clear any API key from env
-
-	// Wait for the UniFi API to be fully operational. The container may be
-	// "healthy" per Docker but the API might not be ready yet.
-	fmt.Printf("Waiting for UniFi API at %s...\n", endpoint)
-	if err := waitForAPI(ctx, endpoint, "admin", "admin"); err != nil {
-		fmt.Fprintf(os.Stderr, "API never became ready: %s\n", err)
-		return 1
-	}
-
-	fmt.Println("UniFi API ready, running tests...")
-	return m.Run()
-}
-
-// waitForAPI polls the UniFi API until login succeeds and basic endpoints respond.
-// The controller can take 60-120 seconds to initialize after Docker reports healthy.
-func waitForAPI(ctx context.Context, endpoint, user, pass string) error {
-	maxRetries := 60
-	retryDelay := 3 * time.Second
-
-	for i := range maxRetries {
-		client, err := unifi.New(ctx, &unifi.Config{
-			BaseURL:       endpoint,
-			Username:      user,
-			Password:      pass,
-			AllowInsecure: true,
-		})
-		if err != nil {
-			if i%10 == 0 {
-				fmt.Printf("  attempt %d/%d: login failed (%s), retrying...\n", i+1, maxRetries, err)
-			}
-			time.Sleep(retryDelay)
-			continue
-		}
-
-		// Verify the sites endpoint responds (confirms the network application is ready).
-		if _, err := client.ListSites(ctx); err != nil {
-			fmt.Printf("  attempt %d/%d: login OK but sites not ready (%s)\n", i+1, maxRetries, err)
-			time.Sleep(retryDelay)
-			continue
-		}
-
-		fmt.Printf("  API ready after %d attempts\n", i+1)
-		return nil
-	}
-
-	return fmt.Errorf("API not ready after %d attempts (%v total)", maxRetries, time.Duration(maxRetries)*retryDelay)
 }
 
 // preCheck validates that the required env vars are set before running an


### PR DESCRIPTION
Follows up on the `testcontainers` point from #159, which you said seemed worth fixing.

## What was happening

`testcontainers-go/modules/compose` is imported only by `TestMain` in `provider_test.go`, but nothing gated that import — so the Docker/containerd/compose-go tree got compiled into the test binary on every `go test` run, including plain unit runs that never start a container.

Measured with `go list -deps -test ./internal/provider/`:

| | docker/containerd/compose-go packages |
|---|---|
| before | **138** |
| after (untagged) | **0** |
| after (`-tags=acc`) | 138 |

## What changed

- The Docker bootstrap (`runDockerTests`, `waitForAPI`) moves to `provider_docker_acc_test.go` behind `//go:build acc`.
- `provider_docker_stub_test.go` (`//go:build !acc`) provides a `runDockerTests` that prints how to enable the tag.
- `TestMain` stays **untagged**, so target dispatch and unit runs behave exactly as before.
- `Taskfile.yml`: `test:acc` gains `-tags=acc`. `test:acc:hardware` deliberately does *not* — it talks to an existing controller, so leaving the tag off keeps the Docker tree out of that build too.
- `vet` gains a second tagged pass, otherwise the acc file rots silently until someone runs `test:acc`.

CI needs no change — `ci-local.yaml` goes through `task test:unit` / `task test:acc`.

## One thing this does not do

Since #159 raised go.mod specifically, I want to be straight about this: **it does not move the dependency out of the main `require` block.** I tried it and checked rather than assuming — `go mod tidy` evaluates all build configurations, so a tagged test import is still a direct requirement and tidy leaves it exactly where it is.

Demoting it for real would mean putting the bootstrap in a separate Go module, which feels disproportionate for what it buys. The part that was actually costing something — compiling 138 packages to run unit tests — is gone, and consumers importing the provider package never had compose in their build anyway, since it was always test-only.

Happy to go the separate-module route instead if you'd rather have the go.mod line gone; just didn't want to make that call unilaterally.

Side effect: it should make Dependabot's compose bumps (#169 currently) cheaper to reason about, since the dependency is now visibly test-only in the source tree.

Written with Claude Code, reviewed by me.
