### PR TITLE
testing: add a UniFi OS Server acceptance target + reference network (un-stacked from #161)

### DIFF
--- a/Taskfile.yml
+++ b/Taskfile.yml
@@ -61,6 +61,19 @@ tasks:
     cmds:
       - go test ./internal/provider/ -v -count 1 -shuffle=on -timeout 10m -run "^TestAcc" {{.CLI_ARGS}}
 
+  test:acc:uos:
+    desc: Run acceptance tests against a UOS Server (bootstrap.sh must have populated env vars)
+    env:
+      TF_ACC: "1"
+      TERRIFI_ACC_TARGET: uos
+    cmds:
+      - go test ./internal/provider/ -v -count 1 -shuffle=on -timeout 10m -run "^TestAcc" {{.CLI_ARGS}}
+
+  uos:bootstrap:
+    desc: Wrap testing/bootstrap.sh — provisions a fresh UOS Server and prints UNIFI_* env vars on stdout
+    cmds:
+      - bash testing/bootstrap.sh
+
   test:cli:
     desc: Run CLI + generate unit tests
     env:

--- a/examples/complete/README.md
+++ b/examples/complete/README.md
@@ -1,0 +1,81 @@
+# examples/complete
+
+The EXAMPLE_NETWORK reference network (a role-based, dual-WAN/multi-VLAN
+homelab shape, stripped of identifying detail) expressed with terrifi's
+implemented resources. It is the fixture the end-to-end acceptance test
+(`TestAccCompleteNetwork_basic`) applies, re-plans for idempotency, and
+destroys.
+
+## Files
+
+| File | What |
+|---|---|
+| `main.tf` | The appliable core — networks, WLANs, firewall groups, DNS records, client group, client reservations. Applies cleanly on the `docker` and `uos` targets (no adopted gateway needed). |
+| `firewall-zbf.tf` | Zone-based firewall (zones, policies, ordering), gated behind `enable_zone_firewall` (default `false`). Needs an adopted gateway — see note below. |
+| `stubs.tf` | Commented-out blocks for resources terrifi does not implement yet (WAN, port profiles, port forwards, routes, RADIUS, dynamic DNS), each tagged to its reference section. |
+
+## Apply
+
+```sh
+# Appliable core only (docker / UOS simulation):
+terraform apply
+
+# Add the zone-based firewall (real adopted hardware only):
+terraform apply -var=enable_zone_firewall=true
+```
+
+Provider credentials come from the environment (`UNIFI_API`,
+`UNIFI_API_KEY` or `UNIFI_USERNAME`/`UNIFI_PASSWORD`, `UNIFI_INSECURE`).
+
+This directory is also the fixture for `TestAccCompleteNetwork_basic`, which
+applies it in-process. terraform-plugin-testing requires a test-applied
+config to declare no providers of its own, so — unlike the other examples —
+there is no `terraform { required_providers {} }` block here. Under the
+repo's `dev_overrides` workflow you don't need one. To run against a registry
+build, drop a `versions.tf` in this directory:
+
+```hcl
+terraform {
+  required_providers {
+    terrifi = { source = "alexklibisz/terrifi" }
+  }
+}
+```
+
+## Why the zone-based firewall is gated off
+
+`terrifi_firewall_zone` / `_policy` / `_policy_order` require the controller
+to have seeded its default zones (Internal, External, DMZ, Hotspot, IoT,
+VPN), which only happens once a real gateway is adopted and Connected.
+Neither the docker simulation nor a fresh UOS Server in simulation mode
+seeds them, so a zone create returns `api.err.CouldNotFindHotspotFirewallZone`.
+Confirmed on Network app 10.3.58 and 10.4.57 — see
+`testing/README.md` → "firewall zones require real adopted hardware". The
+toggle keeps the core example applying everywhere while still exercising the
+ZBF resources on a hardware target.
+
+## A note on controller load
+
+`TestAccCompleteNetwork_basic` applies this whole directory at once, so
+Terraform creates ~14 resources with its default parallelism (10). Against a
+fresh docker controller this completes in a few seconds. Against a modestly
+resourced controller that is **also running adopted (or simulated) devices**,
+the burst of concurrent `networkconf` writes can each exceed the provider's
+30 s HTTP timeout, because the controller recomputes device configuration on
+every network change. If you hit `context deadline exceeded` running this on
+such a target, run it against an idle controller (no adopted/simulated
+devices), or apply with reduced parallelism (`terraform apply
+-parallelism=2`). The per-resource acceptance tests already prove each
+resource individually; this fixture proves they compose.
+
+## Coverage vs. the reference
+
+Implemented and exercised here: `terrifi_network` (×5), `terrifi_wlan` (×3),
+`terrifi_firewall_group` (×2), `terrifi_dns_record` (×3),
+`terrifi_client_group` (×1), `terrifi_client_device` (×3), and — behind the
+toggle — `terrifi_firewall_zone` / `_policy` / `_policy_order`.
+
+Not yet implemented (see `stubs.tf`): WAN, `purpose=guest` networks, port
+profiles, port forwards / DNAT, static & traffic routes, RADIUS profile/user,
+dynamic DNS. `stubs.tf` records each gap as a commented block; these
+stubs are the running coverage gap.

--- a/examples/complete/firewall-zbf.tf
+++ b/examples/complete/firewall-zbf.tf
@@ -1,0 +1,81 @@
+# examples/complete — zone-based firewall slice.
+#
+# terrifi implements UniFi's zone-based firewall (terrifi_firewall_zone,
+# terrifi_firewall_policy, terrifi_firewall_policy_order). These resources
+# REQUIRE an adopted gateway: the controller only seeds the default zones
+# (Internal, External, DMZ, Hotspot, IoT, VPN) once a UGW reaches the
+# Connected state, and a user zone cannot be created until the "Hotspot"
+# parent zone exists. Neither the docker simulation nor a fresh UOS Server in
+# simulation mode seeds those zones (confirmed on Network app 10.3.58 and
+# 10.4.57 — see testing/README.md "firewall zones require real adopted
+# hardware"). So these are gated behind a toggle, OFF by default, and applied
+# only against a real hardware target.
+#
+#   terraform apply                              # ZBF off (docker / UOS sim)
+#   terraform apply -var=enable_zone_firewall=true   # ZBF on (real hardware)
+
+variable "enable_zone_firewall" {
+  type        = bool
+  default     = false
+  description = "Create the zone-based firewall resources. Requires an adopted gateway with the default zones seeded; leave false on docker/UOS simulation."
+}
+
+resource "terrifi_firewall_zone" "trusted" {
+  count = var.enable_zone_firewall ? 1 : 0
+  name  = "tfacc-zone-trusted"
+  network_ids = [
+    terrifi_network.trusted.id,
+  ]
+}
+
+resource "terrifi_firewall_zone" "iot" {
+  count = var.enable_zone_firewall ? 1 : 0
+  name  = "tfacc-zone-iot"
+  network_ids = [
+    terrifi_network.iot.id,
+  ]
+}
+
+# Allow IoT -> Trusted only on the Home-Assistant / MQTT / HTTPS ports.
+resource "terrifi_firewall_policy" "iot_to_trusted_mgmt" {
+  count    = var.enable_zone_firewall ? 1 : 0
+  name     = "tfacc-fw-iot-to-trusted-mgmt"
+  action   = "ALLOW"
+  protocol = "tcp"
+
+  source {
+    zone_id = terrifi_firewall_zone.iot[0].id
+  }
+
+  destination {
+    zone_id        = terrifi_firewall_zone.trusted[0].id
+    port_group_id  = terrifi_firewall_group.iot_mgmt_allowed.id
+  }
+}
+
+# Block everything else IoT -> Trusted.
+resource "terrifi_firewall_policy" "iot_to_trusted_block" {
+  count  = var.enable_zone_firewall ? 1 : 0
+  name   = "tfacc-fw-iot-to-trusted-block"
+  action = "BLOCK"
+
+  source {
+    zone_id = terrifi_firewall_zone.iot[0].id
+  }
+
+  destination {
+    zone_id = terrifi_firewall_zone.trusted[0].id
+  }
+}
+
+# Allow the management ports first, then the catch-all block.
+resource "terrifi_firewall_policy_order" "iot_to_trusted" {
+  count               = var.enable_zone_firewall ? 1 : 0
+  source_zone_id      = terrifi_firewall_zone.iot[0].id
+  destination_zone_id = terrifi_firewall_zone.trusted[0].id
+
+  policy_ids = [
+    terrifi_firewall_policy.iot_to_trusted_mgmt[0].id,
+    terrifi_firewall_policy.iot_to_trusted_block[0].id,
+  ]
+}

--- a/examples/complete/main.tf
+++ b/examples/complete/main.tf
@@ -1,0 +1,201 @@
+# examples/complete — the EXAMPLE_NETWORK reference, expressed in terrifi.
+#
+# A role-based ("cattle, not pets") UniFi Network configuration that exercises
+# the breadth of terrifi's implemented resources. Every name carries the
+# `tfacc-` prefix so the test sweep can find and delete leftovers. See
+# stubs.tf for the resources the reference network needs that terrifi does not
+# §8 (L06/L07) for how the end-to-end test consumes this.
+#
+# Scope: this file holds the resources that apply cleanly against the docker
+# simulation and a fresh UOS Server (no adopted gateway required) —
+# networks, WLANs, firewall groups, DNS records, client groups, and client
+# reservations. The zone-based firewall resources live in firewall-zbf.tf,
+# gated behind a toggle because they need an adopted gateway (see that file).
+# Resources terrifi does not implement yet are catalogued in stubs.tf.
+
+# NOTE: this directory is consumed by the TestAccCompleteNetwork_basic
+# acceptance test (improvement-plan §8 L07), which applies it via
+# ConfigDirectory and injects the provider in-process. terraform-plugin-testing
+# requires that a test-applied config NOT declare providers itself, so there is
+# deliberately no `terraform { required_providers {} }` or `provider "terrifi"`
+# block here. Provider config comes from UNIFI_* env vars.
+#
+# To run this example by hand against a registry build, add a versions.tf:
+#
+#   terraform {
+#     required_providers {
+#       terrifi = { source = "alexklibisz/terrifi" }
+#     }
+#   }
+#
+# (Under the documented dev_overrides workflow you don't even need that — see
+# the repo README.) Then `terraform apply`.
+
+variable "wifi_passphrase" {
+  type        = string
+  sensitive   = true
+  default     = "tfacc-wifi-test-passphrase"
+  description = "WPA2 passphrase shared by the test WLANs. A fixed sentinel — never a real one."
+}
+
+# ---------------------------------------------------------------------------
+# Networks (VLANs)
+#
+# Reference has 5 user networks + 2 WANs. terrifi has no WAN resource, so the
+# two WANs are omitted (tracked in stubs.tf). terrifi_network.purpose only
+# supports "corporate" and "vlan-only" — the reference's purpose="guest"
+# network is modeled as corporate here, with client isolation enforced at the
+# WLAN layer instead. That purpose=guest gap is noted in stubs.tf.
+# ---------------------------------------------------------------------------
+
+resource "terrifi_network" "mgmt" {
+  name       = "tfacc-net-mgmt"
+  purpose    = "corporate"
+  vlan_id    = 10
+  subnet     = "192.168.10.1/24"
+  dhcp_start = "192.168.10.30"
+  dhcp_stop  = "192.168.10.240"
+}
+
+resource "terrifi_network" "trusted" {
+  name       = "tfacc-net-trusted"
+  purpose    = "corporate"
+  vlan_id    = 20
+  subnet     = "192.168.20.1/24"
+  dhcp_start = "192.168.20.30"
+  dhcp_stop  = "192.168.20.240"
+}
+
+resource "terrifi_network" "iot" {
+  name       = "tfacc-net-iot"
+  purpose    = "corporate"
+  vlan_id    = 30
+  subnet     = "192.168.30.1/24"
+  dhcp_start = "192.168.30.30"
+  dhcp_stop  = "192.168.30.240"
+}
+
+# Reference purpose=guest; terrifi has no guest purpose, so corporate +
+# WLAN-level isolation. See stubs.tf "purpose=guest".
+resource "terrifi_network" "guest" {
+  name       = "tfacc-net-guest"
+  purpose    = "corporate"
+  vlan_id    = 40
+  subnet     = "192.168.40.1/24"
+  dhcp_start = "192.168.40.30"
+  dhcp_stop  = "192.168.40.240"
+}
+
+# VLAN-only network (no subnet, no DHCP) — exercises the vlan-only branch.
+resource "terrifi_network" "inner" {
+  name    = "tfacc-net-inner"
+  purpose = "vlan-only"
+  vlan_id = 99
+}
+
+# ---------------------------------------------------------------------------
+# WLANs — all three broadcast the WPA2-PSK test passphrase. Guest + IoT get
+# client isolation via application=hotspot/iot (terrifi's isolation knob).
+# ---------------------------------------------------------------------------
+
+resource "terrifi_wlan" "trusted" {
+  name       = "tfacc-ssid-trusted"
+  passphrase = var.wifi_passphrase
+  network_id = terrifi_network.trusted.id
+}
+
+resource "terrifi_wlan" "iot" {
+  name        = "tfacc-ssid-iot"
+  passphrase  = var.wifi_passphrase
+  network_id  = terrifi_network.iot.id
+  application = "iot"
+}
+
+resource "terrifi_wlan" "guest" {
+  name        = "tfacc-ssid-guest"
+  passphrase  = var.wifi_passphrase
+  network_id  = terrifi_network.guest.id
+  application = "hotspot"
+}
+
+# ---------------------------------------------------------------------------
+# Firewall groups
+# ---------------------------------------------------------------------------
+
+resource "terrifi_firewall_group" "rfc1918" {
+  name    = "tfacc-fg-rfc1918"
+  type    = "address-group"
+  members = ["10.0.0.0/8", "172.16.0.0/12", "192.168.0.0/16"]
+}
+
+resource "terrifi_firewall_group" "iot_mgmt_allowed" {
+  name    = "tfacc-fg-iot-mgmt-allowed"
+  type    = "port-group"
+  members = ["8123", "1883", "443"]
+}
+
+# ---------------------------------------------------------------------------
+# DNS records (controller-side overrides)
+# ---------------------------------------------------------------------------
+
+resource "terrifi_dns_record" "nas" {
+  name        = "nas.example.lan"
+  record_type = "A"
+  value       = "192.168.10.20"
+}
+
+resource "terrifi_dns_record" "auth" {
+  name        = "auth.example.lan"
+  record_type = "A"
+  value       = "192.168.20.10"
+}
+
+resource "terrifi_dns_record" "cname" {
+  name        = "ha.example.lan"
+  record_type = "CNAME"
+  value       = "nas.example.lan"
+}
+
+# ---------------------------------------------------------------------------
+# Client group + reservations (DHCP fixed IPs)
+#
+# MACs use the locally-administered, unicast prefix 02:00:00:ca:ff: so they
+# never collide with anything real on the test bench.
+# ---------------------------------------------------------------------------
+
+resource "terrifi_client_group" "iot_devices" {
+  name = "tfacc-cg-iot"
+}
+
+resource "terrifi_client_device" "nas" {
+  mac        = "02:00:00:ca:ff:01"
+  name       = "tfacc-client-nas"
+  fixed_ip   = "192.168.10.20"
+  network_id = terrifi_network.mgmt.id
+}
+
+resource "terrifi_client_device" "auth" {
+  mac        = "02:00:00:ca:ff:02"
+  name       = "tfacc-client-auth"
+  fixed_ip   = "192.168.20.10"
+  network_id = terrifi_network.trusted.id
+}
+
+resource "terrifi_client_device" "iot_hub" {
+  mac              = "02:00:00:ca:ff:03"
+  name             = "tfacc-client-iot-hub"
+  fixed_ip         = "192.168.30.20"
+  network_id       = terrifi_network.iot.id
+  client_group_ids = [terrifi_client_group.iot_devices.id]
+}
+
+# ---------------------------------------------------------------------------
+# Device data source — devices are adopted out-of-band (zero-device CI by
+# default), so this is a data source, not a managed resource. Looked up by
+# the role-based hostname the reference expects. Commented out by default
+# because it errors when no device with that name exists (the common CI case).
+# ---------------------------------------------------------------------------
+
+# data "terrifi_device" "gateway" {
+#   name = "tfacc-gw01"
+# }

--- a/examples/complete/stubs.tf
+++ b/examples/complete/stubs.tf
@@ -1,0 +1,63 @@
+# examples/complete — coverage stubs.
+#
+# The reference network this example is modelled on describes resources
+# terrifi does not implement yet. They are recorded here as commented blocks
+# so the gap is visible alongside the working config and reviewers can see
+# exactly what the reference network needs next. Each block names the upstream
+# UniFi concept, the reference section it comes from, and the §5 resource-
+# it. When terrifi grows one of these resources, lift its block out of here
+# into main.tf (or firewall-zbf.tf).
+#
+# None of these are valid HCL yet — they are intentionally commented out.
+
+# --- WAN (dual ISP) ----------------------------------------------- §5 R08 --
+# Reference §WAN. No terrifi_wan resource (R08). The reference's tfacc-wan-isp1
+# (primary) / tfacc-wan-isp2 (failover) cannot be expressed today.
+#
+# resource "terrifi_wan" "isp1" { ... }   # primary, DHCP dual-stack
+# resource "terrifi_wan" "isp2" { ... }   # failover
+
+# --- purpose=guest network ------------------------------------- §6 (schema) --
+# Reference §Networks. terrifi_network.purpose only accepts corporate|vlan-only.
+# tfacc-net-guest is modeled as corporate in main.tf; the controller's native
+# guest-policy branch (captive portal, voucher hooks) is unmanaged. This is a
+# schema gap on an existing resource (§6 / finding F-001), not a new resource.
+#
+# resource "terrifi_network" "guest_native" { purpose = "guest" ... }
+
+# --- Port profiles ------------------------------------------------ §5 R06 --
+# Reference §Port profiles (6 profiles). No terrifi_port_profile resource (R06).
+#
+# resource "terrifi_port_profile" "trunk_all"      { ... }
+# resource "terrifi_port_profile" "ap_uplink"      { ... }
+# resource "terrifi_port_profile" "access_trusted" { ... }
+# resource "terrifi_port_profile" "access_iot"     { ... }
+# resource "terrifi_port_profile" "access_guest"   { ... }
+# resource "terrifi_port_profile" "dot1x"          { ... }   # 802.1X / RADIUS
+
+# --- Port forwards / DNAT capture --------------------------------- §5 R01 --
+# Reference §Firewall (DNAT capture) + §Inbound. No terrifi_port_forward
+# resource (R01). Blocks the 4 tfacc-pf-dnat-* DNS/NTP captures and
+# tfacc-pf-https. The reference also flags wan.interface="lan" as a likely
+# provider gap (finding F-008).
+#
+# resource "terrifi_port_forward" "dnat_dns_iot"  { ... }
+# resource "terrifi_port_forward" "https"         { ... }
+
+# --- Static / traffic routes ------------------------------ §5 R02 / R07 --
+# Reference §Routing. No terrifi_static_route (R02) / terrifi_traffic_route (R07).
+#
+# resource "terrifi_static_route"  "test_net"          { ... }
+# resource "terrifi_traffic_route" "trusted_via_wan1"  { ... }
+
+# --- RADIUS ------------------------------------------------ §5 R03 / R05 --
+# Reference §RADIUS. No terrifi_radius_user (R03) / terrifi_radius_profile (R05).
+# The 802.1X port profile above would bind to the profile.
+#
+# resource "terrifi_radius_profile" "radius"      { ... }
+# resource "terrifi_radius_user"    "radius_user" { ... }
+
+# --- Dynamic DNS -------------------------------------------------- §5 R04 --
+# Reference §Dynamic DNS. No terrifi_dynamic_dns resource (R04).
+#
+# resource "terrifi_dynamic_dns" "cloudflare" { ... }

--- a/internal/provider/complete_network_acc_test.go
+++ b/internal/provider/complete_network_acc_test.go
@@ -1,0 +1,43 @@
+package provider
+
+import (
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-testing/config"
+	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
+	"github.com/hashicorp/terraform-plugin-testing/plancheck"
+)
+
+// TestAccCompleteNetwork_basic applies the examples/complete reference network
+// end to end, proves it is idempotent (a second plan after apply is empty),
+// and lets the framework destroy it. This is the §8 L07 coverage: a single
+// test that exercises the breadth of implemented resources together, catching
+// cross-resource regressions (dependency ordering, shared IDs, drift) that the
+// per-resource tests miss.
+//
+// Target-agnostic: runs against whatever TERRIFI_ACC_TARGET selects (docker,
+// uos, or hardware). The zone-based firewall slice of the example is gated
+// OFF here via enable_zone_firewall=false, because it needs an adopted gateway
+// with the default zones seeded (see testing/README.md and
+// examples/complete/firewall-zbf.tf). A hardware run can flip it on with a
+// separate test or a manual apply.
+func TestAccCompleteNetwork_basic(t *testing.T) {
+	resource.Test(t, resource.TestCase{
+		PreCheck:                 func() { preCheck(t) },
+		ProtoV6ProviderFactories: testAccProtoV6ProviderFactories,
+		Steps: []resource.TestStep{
+			{
+				ConfigDirectory: config.StaticDirectory("../../examples/complete"),
+				ConfigVariables: config.Variables{
+					"enable_zone_firewall": config.BoolVariable(false),
+				},
+				// Idempotency proof: after apply + refresh, the plan must be empty.
+				ConfigPlanChecks: resource.ConfigPlanChecks{
+					PostApplyPostRefresh: []plancheck.PlanCheck{
+						plancheck.ExpectEmptyPlan(),
+					},
+				},
+			},
+		},
+	})
+}

--- a/internal/provider/provider_test.go
+++ b/internal/provider/provider_test.go
@@ -28,6 +28,8 @@ var testAccProtoV6ProviderFactories = map[string]func() (tfprotov6.ProviderServe
 //   - No TF_ACC env var → run unit tests only (fast, no network)
 //   - TF_ACC=1 + TERRIFI_ACC_TARGET=docker → spin up Docker, run acceptance tests
 //   - TF_ACC=1 + TERRIFI_ACC_TARGET=hardware → use existing env vars, run acceptance tests
+//   - TF_ACC=1 + TERRIFI_ACC_TARGET=uos → expects UNIFI_API/UNIFI_API_KEY in env
+//     (set upstream by testing/bootstrap.sh against a running UOS Server)
 func TestMain(m *testing.M) {
 	if os.Getenv("TF_ACC") == "" {
 		// Unit tests only — no Docker, no env vars needed.
@@ -46,8 +48,12 @@ func TestMain(m *testing.M) {
 		// Hardware mode: env vars already set by direnv/.envrc.local.
 		// Just run the tests directly.
 		os.Exit(m.Run())
+	case "uos":
+		// UOS Server mode: env vars set upstream by testing/bootstrap.sh
+		// (typically `eval "$(testing/bootstrap.sh)"`). Just run the tests.
+		os.Exit(m.Run())
 	default:
-		fmt.Fprintf(os.Stderr, "unknown TERRIFI_ACC_TARGET: %s (expected 'docker' or 'hardware')\n", target)
+		fmt.Fprintf(os.Stderr, "unknown TERRIFI_ACC_TARGET: %s (expected 'docker', 'hardware', or 'uos')\n", target)
 		os.Exit(1)
 	}
 }

--- a/testing/CONTROLLER_FINDINGS.md
+++ b/testing/CONTROLLER_FINDINGS.md
@@ -1,0 +1,56 @@
+# Controller findings catalog (F-001 … F-014)
+
+The mock-controller investigation behind the `uos` test target catalogued 14
+controller / provider findings (F-001 … F-014). That investigation was run
+against the upstream `terraform-provider-unifi` provider, so each finding has
+to be re-mapped to terrifi, which has a different (and smaller) resource set
+and owns its own HTTP layer.
+
+**Bottom line: none of the 14 findings map to a currently-failing terrifi
+test.** Each one is either (a) already handled by terrifi and proven by a
+passing acceptance test, (b) not applicable because terrifi doesn't model the
+field, or (c) dormant because terrifi hasn't ported the affected resource
+yet. So there are no `t.Skip("F-NNN…")` markers to add — adding skips to green
+tests would be wrong. This file is the catalog the improvement-plan §8 L08
+calls for; revisit it when a dormant resource lands.
+
+Legend: **handled** = terrifi does the right thing, covered by a passing test ·
+**n/a** = terrifi doesn't expose the affected field · **dormant** = resource
+not ported; re-evaluate when it lands.
+
+| Finding | Upstream subject | terrifi status | Notes |
+|---|---|---|---|
+| F-001 | `unifi_network` doesn't expose `purpose` | **handled (partial)** | terrifi_network exposes `purpose` = `corporate` \| `vlan-only`. `purpose = "guest"` is **not** supported — dormant gap, recorded in `examples/complete/stubs.tf`. Covered by `TestAccNetwork_*` (6/6). |
+| F-002 | `subnet` required even for vlan-only | **handled** | terrifi_network applies a vlan-only network with no subnet. Covered by `TestAccNetwork_vlanOnly`. |
+| F-003 | `data.ap_group` requires `name` | dormant | No terrifi AP-group data source. Re-evaluate if one is added. |
+| F-004 | `data.client_qos_rate` requires `name` | dormant | No terrifi client-QoS-rate resource/data source. |
+| F-005 | default AP group is `"All APs"` not `"Default"` | dormant | Same as F-003 — no AP-group lookup in terrifi. |
+| F-006 | `network.domain_name` round-trips empty | **n/a** | local `unifi.Network` doesn't declare `domain_name`, so it's never sent or diffed. |
+| F-007 | `unifi_firewall_rule` bool `null` vs `false` | dormant | terrifi has no `firewall_rule` (it uses zone-based firewall). The analogous bool-omitempty concern in `firewall_policy` is already handled (see `firewall_policy_api.go`). |
+| F-008 | `port_forward.wan.interface` rejects LAN IDs | dormant | No terrifi port-forward resource. |
+| F-009 | `traffic_route` fails on zero-device controller | dormant | No terrifi traffic-route resource. |
+| F-010 | `port_profile` round-trips 3 fields wrong (2 parts) | dormant | No terrifi port-profile resource. |
+| F-011 | `unifi_wlan` create → `InvalidPayload` from `schedule_with_duration: null` | **handled** | terrifi sends `schedule_with_duration` as `[]`, never `null` (`normalizeWLAN` in `wlan_api.go`). Covered by `TestAccWLAN_*` (23/23 on UOS 5.1.15). |
+| F-012 | `dynamic_dns` → `UnsupportedDynamicDns` | dormant | No terrifi dynamic-DNS resource. |
+| F-013 | `firewall_rule` WAN_IN index 20000+ rejected with devices | dormant | No terrifi `firewall_rule`. |
+| F-014 | `traffic_route` POST 400 (post-F-009) | dormant | No terrifi traffic-route resource. |
+
+## Separate from the F-findings: the zone-based-firewall simulation gap
+
+terrifi's `firewall_zone` / `firewall_policy` / `firewall_policy_order` tests
+are gated `requireHardware(t)` because the controller only seeds the default
+zones (incl. the `Hotspot` parent every user zone needs) once a real gateway
+is adopted and Connected — neither docker nor UOS simulation does this. That
+is **not** one of F-001 … F-014; it is documented in
+`testing/README.md` → "firewall zones require real adopted hardware" and in
+`examples/complete/firewall-zbf.tf`.
+
+## When a dormant resource lands
+
+When terrifi gains one of the unported resources (port profile, port forward,
+static/traffic route, RADIUS profile/user, dynamic DNS, AP-group data
+source), re-read the matching finding above and the full write-up in the
+investigation doc, add the resource's acceptance tests, and — only if a test
+genuinely fails for the documented reason — add a
+`t.Skip("F-NNN: <one-line>")` until the provider catches up. Update this
+catalog's status column at the same time.

--- a/testing/README.md
+++ b/testing/README.md
@@ -1,0 +1,183 @@
+# testing/
+
+Bootstrap scripts for the `uos` acceptance-test target — a third option
+alongside the existing `docker` (default) and `hardware` targets. UOS Server
+is Ubiquiti's first-party packaging of the Network application; using it
+exercises code paths the docker simulation (`linuxserver/unifi-network-application`)
+does not, particularly around firewall zones/policies, WLAN, and client groups.
+
+The scripts are designed to run **as root on a Linux host you control** — a
+Proxmox LXC, a VM, or bare metal. `install-uos-server.sh` provisions UOS
+Server itself (version-pinned); the others bootstrap it and drive the test
+target.
+
+> **This is a local / self-hosted target, not github-hosted CI.** See
+> "Why not github-hosted runners?" below — the UOS installer is built for a
+> bare-root host and does not run cleanly on github-hosted `ubuntu-24.04`
+> runners. The `docker` target remains the community-runnable CI fast path;
+> `uos` is for running the full hardware-gated suite against a real Network
+> application on a host you own.
+
+## Scripts
+
+- `bootstrap.sh` — Walks a fresh UOS Server through first-run setup, creates
+  an integration API key on the admin account, and prints
+  `UNIFI_API=…`, `UNIFI_API_KEY=…`, `UNIFI_INSECURE=true` on stdout. Idempotent
+  — re-running on an already-set-up controller skips the setup step. Pass
+  `ENABLE_FAKE_DEVICES=1` to chain into `enable-simulation.sh`.
+
+- `enable-simulation.sh` — Stops uosserver, edits `system.properties` to set
+  `is_simulation=true` + `demo.num_ugw`/`usw`/`uap`, restarts uosserver, and
+  polls + adopts the synthesized devices via the Network API. Required for
+  any test that depends on an adopted gateway or AP (firewall zones, AP
+  groups, port profiles, traffic routes). Idempotent.
+
+- `verify-devices.sh` — Post-condition: asserts the controller has the
+  expected number of adopted devices. Useful in CI to fail fast if
+  simulation didn't fully synthesize.
+
+- `reset-controller.sh` — Wipes the Network app's data volume (mongo,
+  `system.properties`, keystore) and restarts uosserver. Preserves UOS-level
+  state (admin account, API keys). Use between acceptance-test runs to undo
+  whatever state previous tests left behind. After it returns, run
+  `bootstrap.sh` again to obtain a fresh integration API key (the previous
+  key references the now-wiped Network site and may not work).
+
+## Typical use
+
+```sh
+# 1. Install UOS Server (pinned version, SHA256-verified). Idempotent.
+sudo bash testing/install-uos-server.sh
+
+# 2. Bootstrap admin + API key, and adopt simulated devices. Prints the
+#    UNIFI_* env vars on stdout; eval them into the current shell.
+eval "$(ENABLE_FAKE_DEVICES=1 sudo testing/bootstrap.sh)"
+
+# 3. Run the acceptance suite against UOS (same host, or any host that can
+#    reach UOS over the network — just carry the UNIFI_* vars across).
+export UNIFI_SITE=default
+task test:acc:uos
+```
+
+The three env vars (`UNIFI_API`, `UNIFI_API_KEY`, `UNIFI_INSECURE`) are the
+same ones the existing `hardware` target consumes, so the same provider code
+runs against either.
+
+## Fast local dev loop: Proxmox LXC snapshots
+
+If your UOS Server is hosted in a Proxmox LXC and the storage backend is ZFS
+or any other snapshot-capable driver, snapshot/rollback is dramatically
+faster than running `reset-controller.sh + bootstrap.sh + enable-simulation.sh`
+between test runs. The scripts here remain the canonical CI path (no
+Proxmox dependency); snapshots are a local-dev convenience.
+
+```sh
+# One-time, after the initial bootstrap.sh + ENABLE_FAKE_DEVICES=1:
+pct snapshot <VMID> clean --description "uosserver bootstrapped + 6 simulated devices adopted"
+
+# Between test runs:
+pct rollback <VMID> clean   # ~2 s; controller comes back already-bootstrapped
+
+# To update the baseline (e.g. after upgrading uosserver):
+pct snapshot <VMID> clean-$(date +%Y%m%d) --description "..."  # keep history
+pct delsnapshot <VMID> clean     # only after the new one is proven
+pct snapshot <VMID> clean
+```
+
+Snapshots are a local-dev convenience only; they are not part of any CI
+flow (there is no github-hosted UOS CI — see below).
+
+## Why not github-hosted runners?
+
+We investigated running this target on github-hosted `ubuntu-24.04`
+runners (a `ci-uos-probe.yaml` workflow, 8 dispatched runs) and concluded
+it is not viable without owning the runner. The UOS installer is built for
+a bare-root host and derives the "invoking user" from the audit loginuid /
+cwd owner — which on a github-hosted runner is the non-root `runner`
+account, and is immutable under `sudo` and unaffected by
+`systemd-run --scope`. Its rootless-podman steps then target
+`/home/runner/.config/<subsystem>`, a 0700 home the `uosserver` service
+user can neither traverse nor write. Five layered workarounds each cleared
+one subsystem and surfaced the next:
+
+1. scripts must be executable (`git update-index --chmod=+x`) or invoked
+   as `sudo bash <script>`;
+2. `sudo` keeps `HOME=/home/runner` → `sudo -H`;
+3. installer reads `SUDO_USER`/`LOGNAME` → pin both to root;
+4. `storage.conf` stat denied under runner's 0700 home → pre-seed a
+   traversable config dir;
+5. podman picks the runner's stale system `/usr/bin/pasta` over UOS's
+   bundled v2026 → set `helper_binaries_dir`.
+
+…and the loginuid-driven `/home/runner/<subsystem>` writes (cni, …) never
+stopped. The viable CI paths, if github-hosted-fresh-install is ruled out:
+
+- a **self-hosted runner running as real root** (mirrors the existing
+  `ci-hil.yaml` setup) — no `runner`-user conflict;
+- a **pre-baked UOS VM image / snapshot** the workflow boots instead of
+  installing fresh.
+
+Until one of those exists, `uos` is a **local / self-hosted target**: run
+the steps in "Typical use" on a host you control. The `docker` target
+(`task test:acc`) remains the github-hosted community CI path.
+
+## Known limitation: `enable-simulation.sh` does not converge on UOS 5.1.15
+
+On UOS Server 5.1.15 the simulated-device adopt loop never completes:
+`enable-simulation.sh` keeps re-issuing `adopt` and the devices never
+reach `state=1`, so the script does not return. **Do not run it on
+5.1.15** — bootstrap without `ENABLE_FAKE_DEVICES` instead and accept
+that the hardware-dependent tests fail.
+
+That still leaves a useful bench. Without simulated devices, on 5.1.15:
+
+- Everything that does not need adopted hardware passes — `Network`,
+  `ClientDevice`, `ClientGroup`, `DNSRecord`, `FirewallGroup`, and all
+  but one `WLAN` test.
+- The hardware-dependent surface fails: every `Device*` test, the
+  `FirewallZone` / `FirewallPolicy` family (see the next section), and
+  `TestAccCompleteNetwork_basic`. `TestAccWLAN_updateBand` times out for
+  the same reason.
+
+If you are iterating, snapshotting the VM/container after a successful
+bootstrap and rolling back between runs is much faster than
+re-bootstrapping.
+
+## Known limitation: firewall zones require real adopted hardware
+
+The `terrifi_firewall_zone`, `terrifi_firewall_policy`, and
+`terrifi_firewall_policy_order` resources are gated `requireHardware(t)`
+in their test files for a reason that is **not specific to the
+provider** — it is a controller-side gap in simulation mode.
+
+The v2 `/firewall/zone` endpoint requires the "Hotspot" default zone
+to exist before any user-created zone can be added. Real adopted UGWs
+trigger the controller to seed the six default zones (Internal,
+External, DMZ, Hotspot, IoT, VPN) automatically. The Network app's
+built-in simulation mode does NOT seed them, even after a fully
+adopted simulated UGW reaches `state=1` (Connected). Tried and ruled
+out:
+
+- Creating a guest-purpose network (no effect).
+- Creating a guest WLAN (`is_guest=true`).
+- Direct POST of a zone with `default_zone:true` / `zone_key:"Hotspot"`
+  / `defaultZone:true` / `zoneKey:"Hotspot"` (all four field shapes
+  rejected by the create-zone schema).
+- Hypothetical `/firewall/zone/init` endpoint (returns 405).
+- Toggling a settings flag (no firewall/zone setting key exists).
+
+Confirmed on UOS Server 5.0.8 (Network app `linuxserver/unifi-network-application:10.3.58`)
+and UOS Server 5.1.15 (Network app `10.4.57`).
+
+These tests therefore remain hardware-only and run only via the
+`TERRIFI_ACC_TARGET=hardware` target against a real UniFi deployment.
+The `uos` target validates everything else.
+
+## Defaults
+
+- Admin credentials: `admin` / `TerrifiTest!2026` — override via `ADMIN_USER`
+  and `ADMIN_PASS` if your environment requires it.
+- API key name: `terrifi-test` — repeated bootstrap runs append a timestamp
+  suffix rather than clobbering prior keys.
+- Simulation device counts: 1 UGW, 2 USW, 3 UAP — override via `NUM_UGW`,
+  `NUM_USW`, `NUM_UAP`.

--- a/testing/bootstrap.sh
+++ b/testing/bootstrap.sh
@@ -1,0 +1,158 @@
+#!/usr/bin/env bash
+# testing/bootstrap.sh
+#
+# Take a freshly-installed UniFi OS Server (uosserver.service active,
+# /api/system reachable on https://localhost:11443) from "isSetup=false" to a
+# working integration-API X-API-Key suitable for terrifi acceptance tests.
+#
+# Sequence:
+#   1. Wait for /api/system to respond.
+#   2. POST /api/setup with admin credentials (idempotent: tolerates "Device is
+#      already setup" / "Setup already in progress" by polling deviceState).
+#   3. Log in as that admin (cookie jar + CSRF token extracted from the JWT).
+#   4. Create an integration API key on the admin account.
+#   5. Verify the key works by calling /proxy/network/integration/v1/sites.
+#   6. (Optional, ENABLE_FAKE_DEVICES=1) call enable-simulation.sh to adopt
+#      simulated UGW/USW/UAP devices — unblocks tests that depend on adopted
+#      hardware (firewall zones/policies, AP groups, port profiles, etc.).
+#
+# Output: prints `UNIFI_API=...`, `UNIFI_API_KEY=...`, `UNIFI_INSECURE=true` on
+# stdout, ready for `eval "$(testing/bootstrap.sh)"` or `>> "$GITHUB_ENV"`. All
+# diagnostics go to stderr.
+#
+# Env overrides:
+#   UOS_URL       (default https://127.0.0.1:11443)
+#   ADMIN_USER    (default admin)
+#   ADMIN_PASS    (default TerrifiTest!2026)
+#   DEVICE_NAME   (default terrifi-test)
+#   TIMEZONE      (default UTC)
+#   KEY_NAME      (default terrifi-test)
+#   ENABLE_FAKE_DEVICES=1 — chain into enable-simulation.sh after key creation.
+
+set -euo pipefail
+
+UOS_URL="${UOS_URL:-https://127.0.0.1:11443}"
+ADMIN_USER="${ADMIN_USER:-admin}"
+ADMIN_PASS="${ADMIN_PASS:-TerrifiTest!2026}"
+DEVICE_NAME="${DEVICE_NAME:-terrifi-test}"
+TIMEZONE="${TIMEZONE:-UTC}"
+KEY_NAME="${KEY_NAME:-terrifi-test}"
+
+log() { printf >&2 '[bootstrap] %s\n' "$*"; }
+
+# 1. Wait until /api/system responds.
+log "Waiting for $UOS_URL/api/system..."
+deadline=$(( $(date +%s) + 300 ))
+until curl -fsSk -o /dev/null "$UOS_URL/api/system"; do
+  [ "$(date +%s)" -lt "$deadline" ] || { log "ERROR: /api/system unreachable after 5 min"; exit 1; }
+  sleep 1
+done
+
+IS_SETUP=$(curl -fsSk "$UOS_URL/api/system" | jq -r .isSetup)
+log "isSetup=$IS_SETUP"
+
+# 2. First-run setup. /api/setup is eventually-consistent: a fresh container
+# can return HTTP 500 "Setup already in progress" or "Device is already setup"
+# while it is still applying the credentials we just sent. Treat those as
+# benign and poll deviceState until it reaches "setup". The login step (#3) is
+# the real success check.
+device_state=$(curl -fsSk "$UOS_URL/api/system" | jq -r .deviceState)
+log "deviceState=$device_state"
+
+if [ "$device_state" != "setup" ]; then
+  log "Running first-run setup as $ADMIN_USER..."
+  setup_body=$(jq -nc \
+    --arg name "$DEVICE_NAME" \
+    --arg tz   "$TIMEZONE" \
+    --arg u    "$ADMIN_USER" \
+    --arg p    "$ADMIN_PASS" \
+    '{name:$name, timezone:$tz, optimizeNetwork:false, sendDiagnostics:false,
+      newAccount:true, advancedSetup:{mode:"dhcp"},
+      username:$u, password:$p}')
+  setup_resp=$(mktemp)
+  http=$(curl -sk -o "$setup_resp" -w '%{http_code}' \
+    -X POST -H 'Content-Type: application/json' \
+    -d "$setup_body" "$UOS_URL/api/setup")
+  body=$(cat "$setup_resp"); rm -f "$setup_resp"
+  case "$http" in
+    200) ;;
+    500)
+      case "$body" in
+        *"Setup already in progress"*|*"Device is already setup"*)
+          log "Setup POST returned $http (transient: $body) — polling for completion"
+          ;;
+        *)
+          log "Setup POST returned $http; body: $body"; exit 1 ;;
+      esac ;;
+    *) log "Setup POST returned $http; body: $body"; exit 1 ;;
+  esac
+
+  log "Waiting for deviceState=setup..."
+  deadline=$(( $(date +%s) + 120 ))
+  while :; do
+    device_state=$(curl -fsSk "$UOS_URL/api/system" | jq -r .deviceState)
+    [ "$device_state" = "setup" ] && break
+    [ "$(date +%s)" -lt "$deadline" ] || { log "ERROR: deviceState stuck at '$device_state'"; exit 1; }
+    sleep 2
+  done
+  log "deviceState=setup reached"
+fi
+
+# 3. Login → cookie jar + CSRF token (extracted from the JWT TOKEN payload).
+COOKIE_JAR=$(mktemp)
+trap 'rm -f "$COOKIE_JAR"' EXIT
+log "Logging in as $ADMIN_USER..."
+login_resp=$(curl -sk -c "$COOKIE_JAR" \
+  -X POST -H 'Content-Type: application/json' \
+  -d "$(jq -nc --arg u "$ADMIN_USER" --arg p "$ADMIN_PASS" \
+        '{username:$u, password:$p, rememberMe:false}')" \
+  "$UOS_URL/api/auth/login")
+USER_ID=$(echo "$login_resp" | jq -r .unique_id)
+[ -n "$USER_ID" ] && [ "$USER_ID" != "null" ] || { log "ERROR: login failed: $login_resp"; exit 1; }
+
+TOKEN=$(awk '/^#HttpOnly_.*TOKEN/ {print $NF}' "$COOKIE_JAR")
+PAYLOAD=$(printf '%s' "$TOKEN" | cut -d. -f2 | tr '_-' '/+')
+while [ $((${#PAYLOAD} % 4)) -ne 0 ]; do PAYLOAD="${PAYLOAD}="; done
+CSRF=$(printf '%s' "$PAYLOAD" | base64 -d 2>/dev/null | jq -r .csrfToken)
+[ -n "$CSRF" ] && [ "$CSRF" != "null" ] || { log "ERROR: could not extract CSRF token"; exit 1; }
+
+# 4. Create an integration API key on the owner account.
+log "Creating API key '$KEY_NAME' on user $USER_ID..."
+key_resp=$(curl -sk -b "$COOKIE_JAR" \
+  -X POST -H 'Content-Type: application/json' \
+  -H "X-CSRF-Token: $CSRF" \
+  -d "$(jq -nc --arg n "$KEY_NAME" '{name:$n}')" \
+  "$UOS_URL/proxy/users/api/v2/user/$USER_ID/keys")
+API_KEY=$(echo "$key_resp" | jq -r '.data.full_api_key // empty')
+[ -n "$API_KEY" ] || { log "ERROR: key creation failed: $key_resp"; exit 1; }
+
+# 5. Verify the key works. The integration API endpoint can return non-JSON
+# error pages for several seconds after a fresh setup or a state reset, so
+# retry until we get a parseable response (or give up after ~30s).
+log "Verifying integration API with new key..."
+deadline=$(( $(date +%s) + 30 ))
+sites=""
+while :; do
+  resp=$(curl -fsSk -H "X-API-KEY: $API_KEY" "$UOS_URL/proxy/network/integration/v1/sites" 2>/dev/null || echo "")
+  sites=$(printf '%s' "$resp" | jq -r '.totalCount // empty' 2>/dev/null || true)
+  [ -n "$sites" ] && break
+  [ "$(date +%s)" -lt "$deadline" ] || { log "WARN: integration API never returned parseable JSON in 30s; key may still be valid"; sites="?"; break; }
+  sleep 2
+done
+log "Integration API reachable with new key; site count=$sites"
+
+# 6. (Optional) Synthesize fake devices via the Network app's simulation mode.
+# Gated by ENABLE_FAKE_DEVICES=1 so the default zero-device behaviour is
+# preserved. Without it, tests that don't need an adopted gateway still work
+# (DNS records, network configs, firewall groups, etc.). With it, the
+# firewall_zone, firewall_policy, and AP-group tests become runnable.
+if [ "${ENABLE_FAKE_DEVICES:-0}" = "1" ]; then
+  here=$(dirname "$0")
+  log "ENABLE_FAKE_DEVICES=1 — running enable-simulation.sh"
+  "$here/enable-simulation.sh" >&2
+fi
+
+# 7. Machine-readable output on stdout.
+printf 'UNIFI_API=%s\n'      "$UOS_URL"
+printf 'UNIFI_API_KEY=%s\n'  "$API_KEY"
+printf 'UNIFI_INSECURE=%s\n' "true"

--- a/testing/enable-simulation.sh
+++ b/testing/enable-simulation.sh
@@ -1,0 +1,185 @@
+#!/usr/bin/env bash
+# testing/enable-simulation.sh
+#
+# Enable UniFi Network's built-in simulation mode on a running uosserver,
+# synthesizing fake devices in mongo so tests that need an adopted gateway
+# (firewall zones, firewall policies, AP groups, port profiles) become
+# runnable. Same `is_simulation=true` trick the docker-based acceptance
+# target uses against `linuxserver/unifi-network-application` — applied here
+# to the first-party UOS Server.
+#
+# Idempotent: re-running strips prior simulation flags from system.properties
+# and re-appends them with the current NUM_* values.
+#
+# Requirements:
+#   - Run as root on the host where uosserver is installed.
+#   - bootstrap.sh has already provisioned the admin account.
+#
+# Env overrides:
+#   NUM_UGW      (default 1)
+#   NUM_USW      (default 2)
+#   NUM_UAP      (default 3)
+#   UOS_URL      (default https://127.0.0.1:11443)
+#   ADMIN_USER   (default admin)
+#   ADMIN_PASS   (default TerrifiTest!2026)
+#
+# Stdout: a single line `UNIFI_FAKE_DEVICES=<count>` for CI assertion.
+# Stderr: progress logs.
+
+set -euo pipefail
+
+NUM_UGW="${NUM_UGW:-1}"
+NUM_USW="${NUM_USW:-2}"
+NUM_UAP="${NUM_UAP:-3}"
+UOS_URL="${UOS_URL:-https://127.0.0.1:11443}"
+ADMIN_USER="${ADMIN_USER:-admin}"
+ADMIN_PASS="${ADMIN_PASS:-TerrifiTest!2026}"
+
+SP_HOST=/home/uosserver/.local/share/containers/storage/volumes/uosserver_var_lib_unifi/_data/system.properties
+
+log() { printf >&2 '[enable-simulation] %s\n' "$*"; }
+
+[ -f "$SP_HOST" ] || { log "ERROR: $SP_HOST not found — has uosserver been installed?"; exit 1; }
+
+log "stopping uosserver"
+systemctl stop uosserver
+# Wait until the container is fully exited; podman state transitions through "stopping".
+for i in $(seq 1 30); do
+  state=$(sudo -iu uosserver podman ps -a --format '{{.State}}' --filter name=uosserver 2>/dev/null || echo "")
+  case "$state" in
+    exited|created|"") break ;;
+  esac
+  sleep 1
+done
+
+log "stripping any prior simulation flags from $SP_HOST"
+sed -i '/^is_simulation=/d; /^demo\.num_/d' "$SP_HOST"
+
+log "appending is_simulation=true with $NUM_UGW UGW / $NUM_USW USW / $NUM_UAP UAP"
+cat >> "$SP_HOST" <<EOF
+is_simulation=true
+demo.num_ugw=$NUM_UGW
+demo.num_usw=$NUM_USW
+demo.num_uap=$NUM_UAP
+EOF
+
+log "starting uosserver"
+systemctl start uosserver
+
+log "waiting for controller HTTPS up"
+deadline=$(( $(date +%s) + 180 ))
+until curl -fsSk -o /dev/null "$UOS_URL/api/ping"; do
+  [ "$(date +%s)" -lt "$deadline" ] || { log "ERROR: controller did not come up in 3 min"; exit 1; }
+  sleep 1
+done
+
+# Network app behind /proxy/network warms up a few seconds after /api/ping returns 204.
+log "waiting for legacy API"
+deadline=$(( $(date +%s) + 90 ))
+while :; do
+  http=$(curl -sk -o /dev/null -w '%{http_code}' "$UOS_URL/proxy/network/api/s/default/stat/device" || echo 0)
+  case "$http" in
+    200|401) break ;;
+  esac
+  [ "$(date +%s)" -lt "$deadline" ] || { log "ERROR: legacy API didn't come up in 90 s (last: $http)"; exit 1; }
+  sleep 2
+done
+
+log "logging in"
+COOKIE=$(mktemp)
+trap 'rm -f "$COOKIE"' EXIT
+curl -fsSk -c "$COOKIE" -o /dev/null \
+  -X POST -H 'Content-Type: application/json' \
+  -d "$(jq -nc --arg u "$ADMIN_USER" --arg p "$ADMIN_PASS" '{username:$u,password:$p,rememberMe:false}')" \
+  "$UOS_URL/api/auth/login"
+TOKEN=$(awk '/^#HttpOnly_.*TOKEN/ {print $NF}' "$COOKIE")
+PAYLOAD=$(printf '%s' "$TOKEN" | cut -d. -f2 | tr '_-' '/+')
+while [ $((${#PAYLOAD} % 4)) -ne 0 ]; do PAYLOAD="${PAYLOAD}="; done
+CSRF=$(printf '%s' "$PAYLOAD" | base64 -d 2>/dev/null | jq -r .csrfToken)
+
+expected=$(( NUM_UGW + NUM_USW + NUM_UAP ))
+
+# Synthesis can take 2–4 minutes when the Network app starts on a freshly
+# wiped data volume (post-reset-controller.sh); a warm restart populates
+# the device list within ~30s. Use a generous deadline to cover both.
+log "polling for $expected synthetic devices"
+deadline=$(( $(date +%s) + 240 ))
+count=0
+while :; do
+  count=$(curl -fsSk -b "$COOKIE" "$UOS_URL/proxy/network/api/s/default/stat/device" \
+          | jq '.data | length' 2>/dev/null || echo 0)
+  [ "$count" -ge "$expected" ] && break
+  [ "$(date +%s)" -lt "$deadline" ] || break
+  sleep 3
+done
+
+if [ "$count" -lt "$expected" ]; then
+  log "ERROR: expected $expected devices, got $count after 4 min"
+  printf 'UNIFI_FAKE_DEVICES=%d\n' "$count"
+  exit 1
+fi
+
+log "adopting all $count devices"
+curl -fsSk -b "$COOKIE" "$UOS_URL/proxy/network/api/s/default/stat/device" > /tmp/.dev.$$
+trap 'rm -f /tmp/.dev.$$ "$COOKIE"' EXIT
+for mac in $(jq -r '.data[] | select(.adopted | not) | .mac' /tmp/.dev.$$); do
+  http=$(curl -sk -b "$COOKIE" -H "X-CSRF-Token: $CSRF" -H 'Content-Type: application/json' \
+    -X POST -o /dev/null -w '%{http_code}' \
+    -d "$(jq -nc --arg m "$mac" '{cmd:"adopt",mac:$m}')" \
+    "$UOS_URL/proxy/network/api/s/default/cmd/devmgr")
+  log "adopt $mac -> HTTP $http"
+done
+
+# Poll until every device is BOTH adopted=true AND state=1 (Connected).
+# The UGW in particular stays in state=7 (Adopting) for a while after its
+# adopt-cmd returns 200; until it reaches state=1 the controller has not
+# provisioned its config and has not created the default firewall zones
+# (Internal, External, DMZ, Hotspot, IoT, VPN), which blocks every
+# firewall-zone and firewall-policy test that follows.
+log "waiting for all $count devices to settle into adopted=true AND state=1 (Connected)"
+deadline=$(( $(date +%s) + 240 ))
+while :; do
+  not_ready=$(curl -fsSk -b "$COOKIE" "$UOS_URL/proxy/network/api/s/default/stat/device" \
+              | jq '[.data[] | select((.adopted | not) or (.state != 1))] | length')
+  [ "$not_ready" = "0" ] && break
+  if [ "$(date +%s)" -ge "$deadline" ]; then
+    log "WARN: $not_ready device(s) still not adopted+state=1 after 4 min — re-issuing adopt for unadopted ones"
+    curl -fsSk -b "$COOKIE" "$UOS_URL/proxy/network/api/s/default/stat/device" \
+      | jq -r '.data[] | select(.adopted | not) | .mac' \
+      | while read mac; do
+          curl -sk -b "$COOKIE" -H "X-CSRF-Token: $CSRF" -H 'Content-Type: application/json' \
+            -X POST -o /dev/null -w "re-adopt $mac %{http_code}\n" \
+            -d "$(jq -nc --arg m "$mac" '{cmd:"adopt",mac:$m}')" \
+            "$UOS_URL/proxy/network/api/s/default/cmd/devmgr"
+        done >&2
+    deadline=$(( $(date +%s) + 120 ))
+    continue
+  fi
+  sleep 3
+done
+log "all $count devices adopted and in Connected state"
+
+# Now wait for the controller to seed the default firewall zones. Even after
+# the UGW reaches state=1, the controller-side seeder takes another moment
+# to populate Internal/External/DMZ/Hotspot/IoT/VPN. Poll until at least one
+# zone with zone_key=Hotspot exists — that's the parent reference downstream
+# user zones implicitly depend on.
+log "waiting for default firewall zones (Internal, External, DMZ, Hotspot, IoT, VPN)"
+deadline=$(( $(date +%s) + 120 ))
+while :; do
+  hotspot_count=$(curl -fsSk -b "$COOKIE" \
+                  "$UOS_URL/proxy/network/v2/api/site/default/firewall/zone" \
+                  | jq '[.[] | select(.zone_key == "Hotspot")] | length' 2>/dev/null || echo 0)
+  [ "$hotspot_count" -ge 1 ] && break
+  if [ "$(date +%s)" -ge "$deadline" ]; then
+    log "WARN: default firewall zones not seeded after 2 min — firewall tests will likely fail"
+    break
+  fi
+  sleep 3
+done
+zone_count=$(curl -fsSk -b "$COOKIE" \
+             "$UOS_URL/proxy/network/v2/api/site/default/firewall/zone" \
+             | jq 'length' 2>/dev/null || echo 0)
+log "controller has $zone_count default firewall zone(s)"
+
+printf 'UNIFI_FAKE_DEVICES=%d\n' "$count"

--- a/testing/install-uos-server.sh
+++ b/testing/install-uos-server.sh
@@ -1,0 +1,110 @@
+#!/usr/bin/env bash
+# testing/install-uos-server.sh
+#
+# Downloads and installs a pinned UniFi OS Server release on a Debian-based
+# Linux host (LXC, VM, or bare metal). Run as root. Idempotent: re-running
+# when the requested version is already installed is a no-op.
+#
+# After install completes:
+#   - systemd unit `uosserver.service` is active
+#   - https://127.0.0.1:11443/api/system responds (after ~30 s warm-up)
+#   - Run testing/bootstrap.sh next to provision admin + API key
+#
+# Updating to a newer release:
+#   1. Hit https://fw-update.ubnt.com/api/firmware-latest?filter=eq~~product~~unifi-os-server
+#      to get the latest Linux x64 entry — the JSON includes the download URL,
+#      version string, and SHA256.
+#   2. Update UOS_VERSION, UOS_URL, and UOS_SHA256 below.
+#   3. Commit the change with the upstream changelog reference.
+
+set -euo pipefail
+
+# Pinned release — see "Updating" comment block above.
+UOS_VERSION="${UOS_VERSION:-5.1.15}"
+UOS_URL="${UOS_URL:-https://fw-download.ubnt.com/data/unifi-os-server/24e0-linux-x64-5.1.15-926621de-c9d7-48cd-8921-a0ff3eebd3f4.15-x64}"
+UOS_SHA256="${UOS_SHA256:-04c8e401eb34330fe99d94f35aa351e0e0e97895f0d9a4b459ff34fb50cad2bb}"
+
+INSTALLER=/tmp/uos-server-installer-${UOS_VERSION}
+LOG=/tmp/uos-install-${UOS_VERSION}.log
+
+log() { printf >&2 '[install-uos-server] %s\n' "$*"; }
+
+[ "$(id -u)" = "0" ] || { log "ERROR: must run as root"; exit 1; }
+
+# Normalize the environment to "running directly as root". The Ubiquiti
+# installer keys its rootless-podman config path off the invoking user,
+# which it derives from SUDO_USER and (as a fallback) LOGNAME/USER. When
+# invoked via `sudo` from a non-root login (e.g. `sudo bash
+# install-uos-server.sh` on a GitHub runner as the `runner` user), the
+# installer's image-load step reads
+# /home/<that-user>/.config/containers/storage.conf and fails with
+# "permission denied" / "Broken pipe" (the uosserver user can't read
+# another user's 0700 home). Pinning every "who am I" signal to root makes
+# the install behave like a bare-root invocation, which is how it works on
+# the dev host (pct exec runs as root with no login session). Confirmed via
+# `grep -a` on the installer ELF that it references SUDO_USER and LOGNAME.
+unset SUDO_USER SUDO_UID SUDO_GID
+export HOME=/root
+export USER=root
+export LOGNAME=root
+export XDG_CONFIG_HOME=/root/.config
+
+# Skip if the target version is already installed.
+if command -v uosserver >/dev/null 2>&1; then
+  current=$(uosserver version 2>/dev/null | head -1 || echo "unknown")
+  if [ "$current" = "$UOS_VERSION" ]; then
+    log "UOS Server $UOS_VERSION already installed; nothing to do"
+    exit 0
+  fi
+  log "found existing UOS Server $current; will replace with $UOS_VERSION"
+  log "running uosserver-purge to remove the existing install"
+  # uosserver-purge prompts y/N and has no flag to bypass; feed it `y` on stdin.
+  echo y | uosserver-purge 2>&1 | tee -a "$LOG" || {
+    log "WARN: uosserver-purge returned non-zero; continuing"
+  }
+fi
+
+# Dependencies the installer assumes are present.
+log "ensuring podman, slirp4netns, curl, jq are installed"
+apt-get update -qq
+apt-get install -y --no-install-recommends podman slirp4netns curl jq ca-certificates >/dev/null
+
+# Download (with resume).
+log "downloading $UOS_URL -> $INSTALLER"
+curl -fsSL -o "$INSTALLER" -C - "$UOS_URL"
+
+# Verify checksum.
+log "verifying SHA256"
+actual=$(sha256sum "$INSTALLER" | awk '{print $1}')
+if [ "$actual" != "$UOS_SHA256" ]; then
+  log "ERROR: SHA256 mismatch"
+  log "  expected: $UOS_SHA256"
+  log "  actual:   $actual"
+  exit 1
+fi
+
+# Run the installer. Ubiquiti distributes a native ELF binary, not a shell
+# script — invoke it directly with chmod +x. Feed `y` on stdin to accept
+# any interactive prompts the installer might surface.
+log "running installer (this takes 2-3 minutes; output goes to $LOG)"
+chmod +x "$INSTALLER"
+yes y | "$INSTALLER" 2>&1 | tee -a "$LOG"
+
+# Confirm the service is up.
+log "waiting for uosserver.service to be active"
+deadline=$(( $(date +%s) + 120 ))
+while ! systemctl is-active uosserver >/dev/null 2>&1; do
+  [ "$(date +%s)" -lt "$deadline" ] || { log "ERROR: uosserver did not become active in 2 min"; exit 1; }
+  sleep 2
+done
+
+log "waiting for https://127.0.0.1:11443/api/system to respond"
+deadline=$(( $(date +%s) + 180 ))
+until curl -fsSk -o /dev/null https://127.0.0.1:11443/api/system; do
+  [ "$(date +%s)" -lt "$deadline" ] || { log "ERROR: API never responded"; exit 1; }
+  sleep 2
+done
+
+installed=$(uosserver version 2>/dev/null | head -1)
+log "UOS Server $installed installed and running"
+log "next step: testing/bootstrap.sh to provision admin + API key"

--- a/testing/reset-controller.sh
+++ b/testing/reset-controller.sh
@@ -1,0 +1,85 @@
+#!/usr/bin/env bash
+# testing/reset-controller.sh
+#
+# Resets the UniFi Network application state on a running uosserver host —
+# wipes the Network app's mongo database and configuration so the next start
+# is equivalent to a fresh install. The UOS-level state (admin account, API
+# keys, system settings) is preserved.
+#
+# Intended for between acceptance-test runs in CI: each TestAcc* lifecycle
+# creates resources (firewall zones, policies, networks, …) and is supposed
+# to destroy them, but a panic, timeout, or controller-side limit can leave
+# orphans behind. Running reset-controller.sh restores a known-clean state
+# without re-installing UOS.
+#
+# Sequence:
+#   1. Stop uosserver; wait for the container to exit cleanly.
+#   2. Wipe /home/uosserver/.local/share/containers/storage/volumes/
+#      uosserver_var_lib_unifi/_data — the Network app's data volume
+#      (mongo db, system.properties, keystore, model_lifecycles, etc.).
+#   3. Start uosserver.
+#   4. Wait for /api/system to respond, then for the Network app's legacy API.
+#
+# After this script returns, run testing/bootstrap.sh to obtain a fresh
+# integration API key (the previous key references the wiped Network site).
+#
+# Requirements:
+#   - Run as root on the host where uosserver is installed.
+#
+# Env overrides:
+#   UOS_URL          (default https://127.0.0.1:11443)
+#   UNIFI_DATA_DIR   (default the path above; override only if your container
+#                      storage root is elsewhere)
+
+set -euo pipefail
+
+UOS_URL="${UOS_URL:-https://127.0.0.1:11443}"
+UNIFI_DATA_DIR="${UNIFI_DATA_DIR:-/home/uosserver/.local/share/containers/storage/volumes/uosserver_var_lib_unifi/_data}"
+
+log() { printf >&2 '[reset-controller] %s\n' "$*"; }
+
+[ -d "$UNIFI_DATA_DIR" ] || { log "ERROR: $UNIFI_DATA_DIR not found — has uosserver been installed?"; exit 1; }
+
+log "stopping uosserver"
+systemctl stop uosserver
+
+# Wait until the container is fully exited; podman state transitions through "stopping".
+for i in $(seq 1 30); do
+  state=$(sudo -iu uosserver podman ps -a --format '{{.State}}' --filter name=uosserver 2>/dev/null || echo "")
+  case "$state" in
+    exited|created|"") break ;;
+  esac
+  sleep 1
+done
+
+log "wiping Network app data volume ($UNIFI_DATA_DIR)"
+# Use find -delete instead of rm -rf so we keep the volume directory itself
+# (podman won't recreate it on restart if missing — only the contents are
+# the volatile bit).
+find "$UNIFI_DATA_DIR" -mindepth 1 -delete
+
+log "starting uosserver"
+systemctl start uosserver
+
+log "waiting for /api/system"
+deadline=$(( $(date +%s) + 300 ))
+until curl -fsSk -o /dev/null "$UOS_URL/api/system"; do
+  [ "$(date +%s)" -lt "$deadline" ] || { log "ERROR: /api/system unreachable after 5 min"; exit 1; }
+  sleep 1
+done
+
+# The Network app behind /proxy/network takes a few extra seconds to warm up
+# after /api/system returns 200. Wait until its legacy API is up too so
+# bootstrap.sh's subsequent calls don't race.
+log "waiting for Network app legacy API"
+deadline=$(( $(date +%s) + 120 ))
+while :; do
+  http=$(curl -sk -o /dev/null -w '%{http_code}' "$UOS_URL/proxy/network/api/s/default/stat/device" || echo 0)
+  case "$http" in
+    200|401) break ;;
+  esac
+  [ "$(date +%s)" -lt "$deadline" ] || { log "ERROR: Network app legacy API didn't come up in 2 min (last: $http)"; exit 1; }
+  sleep 2
+done
+
+log "ready — run testing/bootstrap.sh to obtain a fresh API key"

--- a/testing/verify-devices.sh
+++ b/testing/verify-devices.sh
@@ -1,0 +1,64 @@
+#!/usr/bin/env bash
+# testing/verify-devices.sh
+#
+# Asserts that the running uosserver has the expected number of adopted fake
+# devices in simulation mode. Intended as a post-condition check after
+# enable-simulation.sh — useful in CI to fail fast if the controller didn't
+# fully synthesize the simulated UGW/USW/UAP.
+#
+# Reads UNIFI_API and UNIFI_API_KEY from the environment (set by bootstrap.sh
+# or `eval "$(testing/bootstrap.sh)"`). Falls back to UOS_URL +
+# admin/password if no key is set.
+#
+# Env overrides:
+#   UNIFI_API / UOS_URL          (default https://127.0.0.1:11443)
+#   UNIFI_API_KEY                 (preferred — use the bootstrap-issued key)
+#   ADMIN_USER, ADMIN_PASS        (fallback when no API key)
+#   EXPECTED_DEVICES              (default sum of NUM_UGW+NUM_USW+NUM_UAP, or 6
+#                                   if those are unset — matches the default
+#                                   1+2+3 split in enable-simulation.sh)
+#
+# Exit 0 with `UNIFI_FAKE_DEVICES=<n>` on stdout if all expected devices are
+# present and adopted. Exit 1 with a diagnostic on stderr otherwise.
+
+set -euo pipefail
+
+UOS_URL="${UNIFI_API:-${UOS_URL:-https://127.0.0.1:11443}}"
+API_KEY="${UNIFI_API_KEY:-}"
+ADMIN_USER="${ADMIN_USER:-admin}"
+ADMIN_PASS="${ADMIN_PASS:-TerrifiTest!2026}"
+
+NUM_UGW="${NUM_UGW:-1}"
+NUM_USW="${NUM_USW:-2}"
+NUM_UAP="${NUM_UAP:-3}"
+EXPECTED_DEVICES="${EXPECTED_DEVICES:-$(( NUM_UGW + NUM_USW + NUM_UAP ))}"
+
+log() { printf >&2 '[verify-devices] %s\n' "$*"; }
+
+if [ -n "$API_KEY" ]; then
+  AUTH=(-H "X-API-KEY: $API_KEY")
+else
+  log "no UNIFI_API_KEY set — logging in as $ADMIN_USER"
+  COOKIE=$(mktemp)
+  trap 'rm -f "$COOKIE"' EXIT
+  curl -fsSk -c "$COOKIE" -o /dev/null \
+    -X POST -H 'Content-Type: application/json' \
+    -d "$(jq -nc --arg u "$ADMIN_USER" --arg p "$ADMIN_PASS" '{username:$u,password:$p,rememberMe:false}')" \
+    "$UOS_URL/api/auth/login"
+  AUTH=(-b "$COOKIE")
+fi
+
+devices=$(curl -fsSk "${AUTH[@]}" "$UOS_URL/proxy/network/api/s/default/stat/device")
+count=$(echo "$devices" | jq '.data | length')
+adopted=$(echo "$devices" | jq '[.data[] | select(.adopted)] | length')
+
+log "found $count device(s); $adopted adopted; expected $EXPECTED_DEVICES adopted"
+
+if [ "$adopted" -lt "$EXPECTED_DEVICES" ]; then
+  log "ERROR: only $adopted of $EXPECTED_DEVICES expected devices are adopted"
+  echo "$devices" | jq -r '.data[] | "  \(.mac)  adopted=\(.adopted)  type=\(.type)  state=\(.state)"' >&2
+  printf 'UNIFI_FAKE_DEVICES=%d\n' "$adopted"
+  exit 1
+fi
+
+printf 'UNIFI_FAKE_DEVICES=%d\n' "$adopted"


### PR DESCRIPTION
This is the UOS half of #162, **re-rooted directly on `main`** so it no longer sits on top of the SDK tear-out in #161.

You said on #160 that you weren't sold on the tear-out yet, and that it "creates a better test harness for the big SDK tear-out." Stacking #162 on #161 had that backwards — you couldn't take the harness without first accepting the thing you wanted the harness for. This unpicks that. **Nothing here touches `internal/unifi` or go-unifi**: shell scripts, HCL, a Taskfile target, and four lines of `TestMain` dispatch. It applies to `main` as-is.

Feel free to close #162 in favour of this one, or keep it around for the rest — your call.

## Why

The gap is between your two existing targets. `docker` runs anywhere, but the simulated controller diverges from a real one exactly on the paths that matter. `hardware` is faithful, but it's your rig — a contributor can't reach it. UniFi OS Server sits in between: a real Network application, self-hosted, disposable.

That doesn't replace your HIL rig, and isn't meant to. It's the tier below it — enough for a contributor to catch the "CI green, real controller angry" class of failure you described on #159 before it ever reaches you.

```
testing/install-uos-server.sh   pinned installer, idempotent
testing/bootstrap.sh            admin + integration API key, prints UNIFI_* on stdout
testing/enable-simulation.sh    simulated devices (caveat below)
testing/reset-controller.sh     wipe between runs
testing/verify-devices.sh       adoption state check
testing/README.md               setup, limitations, what does and doesn't pass
testing/CONTROLLER_FINDINGS.md  F-001..F-014
```

`TERRIFI_ACC_TARGET=uos` expects `UNIFI_API`/`UNIFI_API_KEY` already in the environment, which `bootstrap.sh` prints — so `TestMain` just runs the tests. No new dependency. `docker` and `hardware` are untouched.

`examples/complete/` is a 5-network / 3-WLAN / firewall-groups + DNS-records reference config, applied by `TestAccCompleteNetwork_basic` through `ConfigDirectory` so the example can't rot. `stubs.tf` records what that reference network needs and terrifi has no resource for yet, as commented blocks — the coverage gap stays visible next to the working config instead of living in someone's notes.

## Two things I hit, documented rather than papered over

- **`enable-simulation.sh` does not converge on UOS 5.1.15.** The adopt loop re-issues forever and devices never reach `state=1`. README says don't run it there, and lists exactly which tests then fail.
- **`firewall_zone` / `firewall_policy` / `firewall_policy_order` still need real adopted hardware.** The controller only seeds the Hotspot default zone once a real gateway is Connected, and simulation never does it. Five workarounds tried and ruled out, all listed in the README. So those stay `requireHardware(t)` — this PR does not pretend to cover them.

`CONTROLLER_FINDINGS.md` catalogues F-001..F-014, each mapped to whether terrifi handles it, doesn't model it, or hasn't ported the resource yet. None of them map to a currently-failing terrifi test, so no `t.Skip` markers were added.

## What I ran

`go vet` and the unit suite pass on this branch. The UOS suite itself I've run against 5.0.8 and 5.1.15 on my own bench; I can't re-run it right now (that host is down), so treat the numbers in the README as from those earlier runs rather than from this exact commit.

Written with Claude Code, reviewed by me.
